### PR TITLE
Update to WebAwesome 3.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
 
+## [3.5.1] - 2026-04-05
+### Fixed
+- **Peer dependencies:** Widened `@angular/common`, `@angular/core`, and `@angular/forms` peer dependency ranges from `^20.3.17` (which only accepted Angular 20.x) to `>=20.0.0`, allowing the library to install and work correctly on Angular 21+ and future Angular versions. The library uses only stable Angular APIs and `compilationMode: "partial"`, so it is fully forward-compatible.
+
+### Notes
+- This is a patch release addressing installation failures when consumers use Angular versions newer than 20.x.
+
+
 ## [3.5.0] - 2026-04-03
 ### Added
 - **wa-button:** New `withStart` and `withEnd` SSR boolean inputs (render `with-start` / `with-end` attributes).
@@ -205,3 +213,4 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 [3.3.2]: https://github.com/GedMarc/angular-awesome/compare/3.3.1...3.3.2
 [3.4.0]: https://github.com/GedMarc/angular-awesome/compare/3.3.2...3.4.0
 [3.5.0]: https://github.com/GedMarc/angular-awesome/compare/3.4.0...3.5.0
+[3.5.1]: https://github.com/GedMarc/angular-awesome/compare/3.5.0...3.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
 
+## [3.5.2] - 2026-04-05
+### Fixed
+- **wa-switch:** Changed directive selector from `wa-switch[waSwitch]` to `wa-switch`, matching the convention used by all other component directives (e.g. `wa-checkbox`, `wa-button`). Previously, consumers had to add the `waSwitch` attribute for the directive to activate; without it, Angular could not bind `@Input()` properties like `[checked]`, causing `NG8002: Can't bind to 'checked' since it isn't a known property of 'wa-switch'`.
+- **wa-switch:** Added `WaSwitchEvent` typed event interface. The `(wa-change)` and `(wa-input)` outputs now emit `WaSwitchEvent` instead of plain `Event`, giving consumers type-safe access to `$event.target.checked` and `$event.target.value` in templates without `TS2339` errors.
+
+### Notes
+- This is a patch release. Existing usages with `waSwitch` continue to work; the attribute is simply no longer required.
+- `WaSwitchEvent` is exported from the public API for consumers who need the type explicitly.
+
+
 ## [3.5.1] - 2026-04-05
 ### Fixed
 - **Peer dependencies:** Widened `@angular/common`, `@angular/core`, and `@angular/forms` peer dependency ranges from `^20.3.17` (which only accepted Angular 20.x) to `>=20.0.0`, allowing the library to install and work correctly on Angular 21+ and future Angular versions. The library uses only stable Angular APIs and `compilationMode: "partial"`, so it is fully forward-compatible.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
 
+## [3.6.0] - 2026-05-01
+### Changed
+- **SizeToken:** Expanded size type to include shorthand tokens `'xs' | 's' | 'm' | 'l' | 'xl'` alongside the existing `'small' | 'medium' | 'large'`, matching Web Awesome 3.6.0. This affects all components with a `size` property: `wa-button`, `wa-callout`, `wa-checkbox`, `wa-color-picker`, `wa-combobox`, `wa-dropdown`, `wa-file-input`, `wa-input`, `wa-number-input`, `wa-radio`, `wa-radio-group`, `wa-rating`, `wa-select`, `wa-slider`, `wa-switch`, `wa-tag`, `wa-textarea`, `wa-toast-item`.
+- **Default size:** Web Awesome 3.6.0 changed the default size from `'medium'` to `'m'`. Angular wrappers pass through whatever value is set; unset inputs continue to use the web component's built-in default.
+
+### Notes
+- The legacy size values (`small`, `medium`, `large`) remain supported for backwards compatibility.
+- This is a minor release aligned with Web Awesome 3.6.0. No breaking changes.
+
+
 ## [3.5.2] - 2026-04-05
 ### Fixed
 - **wa-switch:** Changed directive selector from `wa-switch[waSwitch]` to `wa-switch`, matching the convention used by all other component directives (e.g. `wa-checkbox`, `wa-button`). Previously, consumers had to add the `waSwitch` attribute for the directive to activate; without it, Angular could not bind `@Input()` properties like `[checked]`, causing `NG8002: Can't bind to 'checked' since it isn't a known property of 'wa-switch'`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![npm version](https://img.shields.io/npm/v/angular-awesome.svg)](https://www.npmjs.com/package/angular-awesome)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Angular](https://img.shields.io/badge/Angular-20%2B-dd0031.svg?logo=angular)](https://angular.dev)
-[![TypeScript](https://img.shields.io/badge/TypeScript-5.7-3178c6.svg?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
+[![TypeScript](https://img.shields.io/badge/TypeScript-5.9-3178c6.svg?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)
 
 > Angular 20+ wrapper directives for the [Web Awesome](https://www.webawesome.com/) web-components framework.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 | Dependency | Version |
 |------------|---------|
-| Angular    | `^20.0` |
+| Angular    | `>=20.0` |
 | Node.js    | `20+`   |
 | Web Awesome | `3.5.x` |
 

--- a/docs/components/switch.html
+++ b/docs/components/switch.html
@@ -103,47 +103,47 @@
         <h2>Import</h2>
         <p>Import the switch directive from the angular-awesome package:</p>
         <pre>// Import the switch directive
-import { WaSwitchDirective } from 'angular-awesome/switch';</pre>
+import {Directive } from 'angular-awesome/switch';</pre>
       </section>
 
       <section>
         <h2>Examples</h2>
         <h1>Switch Examples</h1>
 <h2>Basic Usage</h2>
-<pre><code class="language-html">&lt;wa-switch waSwitch&gt;&lt;/wa-switch&gt;
+<pre><code class="language-html">&lt;wa-switch&gt;&lt;/wa-switch&gt;
 </code></pre>
 <h2>Disabled State</h2>
-<pre><code class="language-html">&lt;wa-switch waSwitch disabled&gt;&lt;/wa-switch&gt;
+<pre><code class="language-html">&lt;wa-switch disabled&gt;&lt;/wa-switch&gt;
 </code></pre>
 <h2>With Hint Text</h2>
-<pre><code class="language-html">&lt;wa-switch waSwitch hint=&quot;Enable feature&quot;&gt;&lt;/wa-switch&gt;
+<pre><code class="language-html">&lt;wa-switch hint=&quot;Enable feature&quot;&gt;&lt;/wa-switch&gt;
 </code></pre>
 <h2>Different Sizes</h2>
 <pre><code class="language-html">&lt;!-- Small size --&gt;
-&lt;wa-switch waSwitch size=&quot;small&quot;&gt;&lt;/wa-switch&gt;
+&lt;wa-switch size=&quot;small&quot;&gt;&lt;/wa-switch&gt;
 
 &lt;!-- Medium size (default) --&gt;
-&lt;wa-switch waSwitch size=&quot;medium&quot;&gt;&lt;/wa-switch&gt;
+&lt;wa-switch size=&quot;medium&quot;&gt;&lt;/wa-switch&gt;
 
 &lt;!-- Large size --&gt;
-&lt;wa-switch waSwitch size=&quot;large&quot;&gt;&lt;/wa-switch&gt;
+&lt;wa-switch size=&quot;large&quot;&gt;&lt;/wa-switch&gt;
 </code></pre>
 <h2>Custom Styling</h2>
 <pre><code class="language-html">&lt;!-- Custom background color --&gt;
-&lt;wa-switch waSwitch [backgroundColor]=&quot;&#39;#e0e0e0&#39;&quot; [backgroundColorChecked]=&quot;&#39;#4CAF50&#39;&quot;&gt;&lt;/wa-switch&gt;
+&lt;wa-switch [backgroundColor]=&quot;&#39;#e0e0e0&#39;&quot; [backgroundColorChecked]=&quot;&#39;#4CAF50&#39;&quot;&gt;&lt;/wa-switch&gt;
 
 &lt;!-- Custom border --&gt;
-&lt;wa-switch waSwitch [borderColor]=&quot;&#39;#999&#39;&quot; [borderColorChecked]=&quot;&#39;#2196F3&#39;&quot; [borderWidth]=&quot;&#39;2px&#39;&quot; [borderStyle]=&quot;&#39;solid&#39;&quot;&gt;&lt;/wa-switch&gt;
+&lt;wa-switch [borderColor]=&quot;&#39;#999&#39;&quot; [borderColorChecked]=&quot;&#39;#2196F3&#39;&quot; [borderWidth]=&quot;&#39;2px&#39;&quot; [borderStyle]=&quot;&#39;solid&#39;&quot;&gt;&lt;/wa-switch&gt;
 
 &lt;!-- Custom thumb --&gt;
-&lt;wa-switch waSwitch [thumbColor]=&quot;&#39;#fff&#39;&quot; [thumbColorChecked]=&quot;&#39;#fff&#39;&quot; [thumbSize]=&quot;&#39;16px&#39;&quot; [thumbShadow]=&quot;&#39;0 0 4px rgba(0,0,0,0.3)&#39;&quot;&gt;&lt;/wa-switch&gt;
+&lt;wa-switch [thumbColor]=&quot;&#39;#fff&#39;&quot; [thumbColorChecked]=&quot;&#39;#fff&#39;&quot; [thumbSize]=&quot;&#39;16px&#39;&quot; [thumbShadow]=&quot;&#39;0 0 4px rgba(0,0,0,0.3)&#39;&quot;&gt;&lt;/wa-switch&gt;
 
 &lt;!-- Custom dimensions --&gt;
-&lt;wa-switch waSwitch [width]=&quot;&#39;60px&#39;&quot; [height]=&quot;&#39;30px&#39;&quot;&gt;&lt;/wa-switch&gt;
+&lt;wa-switch [width]=&quot;&#39;60px&#39;&quot; [height]=&quot;&#39;30px&#39;&quot;&gt;&lt;/wa-switch&gt;
 
 &lt;!-- Combined custom styling --&gt;
 &lt;wa-switch 
-  waSwitch 
+  
   [backgroundColor]=&quot;&#39;#f0f0f0&#39;&quot; 
   [backgroundColorChecked]=&quot;&#39;#673AB7&#39;&quot; 
   [borderColor]=&quot;&#39;#ccc&#39;&quot; 
@@ -161,18 +161,18 @@ import { WaSwitchDirective } from 'angular-awesome/switch';</pre>
 <h2>Using with Angular Forms</h2>
 <pre><code class="language-typescript">import { Component } from &#39;@angular/core&#39;;
 import { FormsModule } from &#39;@angular/forms&#39;;
-import { WaSwitchDirective } from &#39;@angular-awesome/directives/switch&#39;;
+import {Directive } from &#39;@angular-awesome/directives/switch&#39;;
 
 @Component({
   selector: &#39;app-switch-demo&#39;,
   template: `
     &lt;div class=&quot;form-group&quot;&gt;
-      &lt;wa-switch waSwitch [(ngModel)]=&quot;isEnabled&quot; hint=&quot;Enable feature&quot;&gt;&lt;/wa-switch&gt;
+      &lt;wa-switch [(ngModel)]=&quot;isEnabled&quot; hint=&quot;Enable feature&quot;&gt;&lt;/wa-switch&gt;
       &lt;p&gt;Feature is {{ isEnabled ? &#39;enabled&#39; : &#39;disabled&#39; }}&lt;/p&gt;
     &lt;/div&gt;
     
     &lt;div class=&quot;form-group&quot;&gt;
-      &lt;wa-switch waSwitch [(ngModel)]=&quot;darkMode&quot; hint=&quot;Dark mode&quot;&gt;&lt;/wa-switch&gt;
+      &lt;wa-switch [(ngModel)]=&quot;darkMode&quot; hint=&quot;Dark mode&quot;&gt;&lt;/wa-switch&gt;
       &lt;p&gt;Dark mode is {{ darkMode ? &#39;on&#39; : &#39;off&#39; }}&lt;/p&gt;
     &lt;/div&gt;
   `,
@@ -186,13 +186,13 @@ export class SwitchDemoComponent {
 </code></pre>
 <h2>Event Handling</h2>
 <pre><code class="language-typescript">import { Component } from &#39;@angular/core&#39;;
-import { WaSwitchDirective } from &#39;@angular-awesome/directives/switch&#39;;
+import {Directive } from &#39;@angular-awesome/directives/switch&#39;;
 
 @Component({
   selector: &#39;app-switch-events-demo&#39;,
   template: `
     &lt;wa-switch 
-      waSwitch 
+      
       [hint]=&quot;&#39;Notifications&#39;&quot;
       (changeEvent)=&quot;onSwitchChange($event)&quot;
       (inputEvent)=&quot;onSwitchInput($event)&quot;
@@ -236,22 +236,22 @@ export class SwitchEventsDemoComponent {
 <h2>Reactive Forms</h2>
 <pre><code class="language-typescript">import { Component, OnInit } from &#39;@angular/core&#39;;
 import { FormBuilder, FormGroup, ReactiveFormsModule } from &#39;@angular/forms&#39;;
-import { WaSwitchDirective } from &#39;@angular-awesome/directives/switch&#39;;
+import {Directive } from &#39;@angular-awesome/directives/switch&#39;;
 
 @Component({
   selector: &#39;app-switch-reactive-form-demo&#39;,
   template: `
     &lt;form [formGroup]=&quot;settingsForm&quot; (ngSubmit)=&quot;onSubmit()&quot;&gt;
       &lt;div class=&quot;form-group&quot;&gt;
-        &lt;wa-switch waSwitch formControlName=&quot;notifications&quot; hint=&quot;Enable notifications&quot;&gt;&lt;/wa-switch&gt;
+        &lt;wa-switch formControlName=&quot;notifications&quot; hint=&quot;Enable notifications&quot;&gt;&lt;/wa-switch&gt;
       &lt;/div&gt;
       
       &lt;div class=&quot;form-group&quot;&gt;
-        &lt;wa-switch waSwitch formControlName=&quot;darkMode&quot; hint=&quot;Dark mode&quot;&gt;&lt;/wa-switch&gt;
+        &lt;wa-switch formControlName=&quot;darkMode&quot; hint=&quot;Dark mode&quot;&gt;&lt;/wa-switch&gt;
       &lt;/div&gt;
       
       &lt;div class=&quot;form-group&quot;&gt;
-        &lt;wa-switch waSwitch formControlName=&quot;autoSave&quot; hint=&quot;Auto-save&quot; [disabled]=&quot;!settingsForm.get(&#39;notifications&#39;)?.value&quot;&gt;&lt;/wa-switch&gt;
+        &lt;wa-switch formControlName=&quot;autoSave&quot; hint=&quot;Auto-save&quot; [disabled]=&quot;!settingsForm.get(&#39;notifications&#39;)?.value&quot;&gt;&lt;/wa-switch&gt;
         &lt;p class=&quot;hint&quot;&gt;Auto-save requires notifications to be enabled&lt;/p&gt;
       &lt;/div&gt;
       

--- a/package-lock.json
+++ b/package-lock.json
@@ -264,13 +264,13 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2003.19",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.19.tgz",
-      "integrity": "sha512-ta8UR4Sh8lolJZw/eE2tMf694FYzZ5NXBo1p5uj4JnqawpLGt1mwJcWX9kZkWAwQko/L51yWsDxX5VjJLPdXcQ==",
+      "version": "0.2003.22",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2003.22.tgz",
+      "integrity": "sha512-gxVOslVweD+Co6gpRVlByHus/3HVAnsl99MobS9PBh8vh2g6bJ011PBgl0TKsP/pqBGawZOkJXYrRPeMKnobYA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.19",
+        "@angular-devkit/core": "20.3.22",
         "rxjs": "7.8.2"
       },
       "engines": {
@@ -280,16 +280,16 @@
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "20.3.19",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.19.tgz",
-      "integrity": "sha512-zh5ci/TXy4oDQXC+MSWIbsTJJ10lI8WXM7cGerwvlFJc+/yo+Js8haeEuapUxliTlXont47pyPcvnzb9RTfNVQ==",
+      "version": "20.3.22",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-20.3.22.tgz",
+      "integrity": "sha512-1vZnZTAjGcCM+86v2al+2eiROiSw0uAWeVllfHSQe0KsKOP1FE8UUUiWChhxVn7vIxypphlfGunkeeIn1C/ZFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "8.18.0",
         "ajv-formats": "3.0.1",
         "jsonc-parser": "3.3.1",
-        "picomatch": "4.0.3",
+        "picomatch": "4.0.4",
         "rxjs": "7.8.2",
         "source-map": "0.7.6"
       },
@@ -308,13 +308,13 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "20.3.19",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.19.tgz",
-      "integrity": "sha512-7ZwThNeCcdKNuFpmrpQvm049v2Y+7CCCoFOzGg0UnH7F+wmaTSwEwLr+NmGJO0shYCUGl1Q/pcF9y58xs2njiQ==",
+      "version": "20.3.22",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-20.3.22.tgz",
+      "integrity": "sha512-gN2XSXRn3eErGEJlH0iSfQZZ7NdxVZNdjSxuVEGBEFhe3cVeC21LzM3GTWW6xwtBb4pxHglFyc7BUFiYtZiYtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.19",
+        "@angular-devkit/core": "20.3.22",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.17",
         "ora": "8.2.0",
@@ -445,14 +445,14 @@
       }
     },
     "node_modules/@angular/build": {
-      "version": "20.3.19",
-      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.19.tgz",
-      "integrity": "sha512-OZO7TMIfzBEpJ7qf5KIio7H18iDm7hsqqWyMy+CtPr5luZXX24gLI17sSLdvwtiD3MbAEoFh7ktkVOmtl6iceA==",
+      "version": "20.3.22",
+      "resolved": "https://registry.npmjs.org/@angular/build/-/build-20.3.22.tgz",
+      "integrity": "sha512-sxjVZU6AZHXyKRHJUMawXOj4qMf3vm8XK6wUejr01UKj6BqW2YWaQO26RpRJssXD2ITTqn6+UBwL7pEwe2a4Jg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@ampproject/remapping": "2.3.0",
-        "@angular-devkit/architect": "0.2003.19",
+        "@angular-devkit/architect": "0.2003.22",
         "@babel/core": "7.28.3",
         "@babel/helper-annotate-as-pure": "7.27.3",
         "@babel/helper-split-export-declaration": "7.24.7",
@@ -468,7 +468,7 @@
         "magic-string": "0.30.17",
         "mrmime": "2.0.1",
         "parse5-html-rewriting-stream": "8.0.0",
-        "picomatch": "4.0.3",
+        "picomatch": "4.0.4",
         "piscina": "5.1.3",
         "rollup": "4.59.0",
         "sass": "1.90.0",
@@ -494,7 +494,7 @@
         "@angular/platform-browser": "^20.0.0",
         "@angular/platform-server": "^20.0.0",
         "@angular/service-worker": "^20.0.0",
-        "@angular/ssr": "^20.3.19",
+        "@angular/ssr": "^20.3.22",
         "karma": "^6.4.0",
         "less": "^4.2.0",
         "ng-packagr": "^20.0.0",
@@ -544,19 +544,19 @@
       }
     },
     "node_modules/@angular/cli": {
-      "version": "20.3.19",
-      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.19.tgz",
-      "integrity": "sha512-ZLGAabT1yA91e0BjhrvsrWfgeeHT6G8sEN8joZzRszNVLWbI+QuTT5CIDNLJ3e00SmA5dpJNIQBcHYpoau7WVA==",
+      "version": "20.3.22",
+      "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-20.3.22.tgz",
+      "integrity": "sha512-0uyQPF0gGuzioWJKNyOzWSQrrC5GiidR+8gz1lODoJTnJZZdsP5n3nvccbcRmhy55B1WByHvQBE+6eDBbh06/g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": "0.2003.19",
-        "@angular-devkit/core": "20.3.19",
-        "@angular-devkit/schematics": "20.3.19",
+        "@angular-devkit/architect": "0.2003.22",
+        "@angular-devkit/core": "20.3.22",
+        "@angular-devkit/schematics": "20.3.22",
         "@inquirer/prompts": "7.8.2",
         "@listr2/prompt-adapter-inquirer": "3.0.1",
         "@modelcontextprotocol/sdk": "1.26.0",
-        "@schematics/angular": "20.3.19",
+        "@schematics/angular": "20.3.22",
         "@yarnpkg/lockfile": "1.1.0",
         "algoliasearch": "5.35.0",
         "ini": "5.0.0",
@@ -579,9 +579,9 @@
       }
     },
     "node_modules/@angular/common": {
-      "version": "20.3.17",
-      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.17.tgz",
-      "integrity": "sha512-Dqd8f8o9MehszTZIB7o7jrERlwLOSK64gNngK14DCQazz5lpIhAF6hBjx7zjHpa7L9eAYPK1TaxQUXypjzj18Q==",
+      "version": "20.3.18",
+      "resolved": "https://registry.npmjs.org/@angular/common/-/common-20.3.18.tgz",
+      "integrity": "sha512-M62oQbSTRmnGavIVCwimoadg/PDWadgNhactMm9fgH0eM9rx+iWBAYJk4VufO0bwOhysFpRZpJgXlFjOifz/Jw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -591,14 +591,14 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/core": "20.3.17",
+        "@angular/core": "20.3.18",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/compiler": {
-      "version": "20.3.17",
-      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.17.tgz",
-      "integrity": "sha512-cj3x6aFk9xOOxX+qEdeN8T5YbnBNWJ4UMHB/LQoDr7/xCJJGa40IhcOAuJeuF2kGqTwx6MCXnvjO8XOQfHhe9g==",
+      "version": "20.3.18",
+      "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-20.3.18.tgz",
+      "integrity": "sha512-AaP/LCiDNcYmF135EEozjyR04NRBT38ZfBHQwjhgwiBBTejmvcpHwJaHSkraLpZqZzE4BQqqmgiQ1EJqxEwLVA==",
       "devOptional": true,
       "license": "MIT",
       "peer": true,
@@ -610,9 +610,9 @@
       }
     },
     "node_modules/@angular/compiler-cli": {
-      "version": "20.3.17",
-      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.17.tgz",
-      "integrity": "sha512-w5pmO1pXO9tUMgUMWstpDmAWh5s1lJWo+2GI/ByaUEgBZkXd2S92sWoDL+bhy+JSvFzdLGdua6BncHBOX7hEjA==",
+      "version": "20.3.18",
+      "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-20.3.18.tgz",
+      "integrity": "sha512-zsoEgLgnblmRbi47YwMghKirJ8IBKJ3+I8TxLBRIBrhx+KHFp+6oeDeLyu9H+djdyk88zexVd09wzR/YK73F0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -633,7 +633,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "20.3.17",
+        "@angular/compiler": "20.3.18",
         "typescript": ">=5.8 <6.0"
       },
       "peerDependenciesMeta": {
@@ -643,9 +643,9 @@
       }
     },
     "node_modules/@angular/core": {
-      "version": "20.3.17",
-      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.17.tgz",
-      "integrity": "sha512-YlQqxMeHI9XJw7I7oM3hYFQd4lQbK37IdlD9ztROIw5FjX6i6lmLU7+X1MQGSRi2r+X9l3IZtl33hRTNvkoUBw==",
+      "version": "20.3.18",
+      "resolved": "https://registry.npmjs.org/@angular/core/-/core-20.3.18.tgz",
+      "integrity": "sha512-B+NQQngd/aDbcfW0zGLis3wTLDeHTeTYMl/mGKQH+HwdPaRCKI1wEtaXaOYVJXkP2FeThocPevB8gLwNlPQUUw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -655,7 +655,7 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/compiler": "20.3.17",
+        "@angular/compiler": "20.3.18",
         "rxjs": "^6.5.3 || ^7.4.0",
         "zone.js": "~0.15.0"
       },
@@ -669,9 +669,9 @@
       }
     },
     "node_modules/@angular/forms": {
-      "version": "20.3.17",
-      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.17.tgz",
-      "integrity": "sha512-iGS6NwzcyJzinbPMapsQtcN0ZJ62vr6hcul+FNa40CaK2ePC04S+C5n+DIphzwnwsFHDBIWuTQRfk/lNYdN1JA==",
+      "version": "20.3.18",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-20.3.18.tgz",
+      "integrity": "sha512-x6/99LfxolyZIFUL3Wr0OrtuXHEDwEz/rwx+WzE7NL+n35yO40t3kp0Sn5uMFwI94i91QZJmXHltMpZhrVLuYg==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -681,16 +681,16 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.3.17",
-        "@angular/core": "20.3.17",
-        "@angular/platform-browser": "20.3.17",
+        "@angular/common": "20.3.18",
+        "@angular/core": "20.3.18",
+        "@angular/platform-browser": "20.3.18",
         "rxjs": "^6.5.3 || ^7.4.0"
       }
     },
     "node_modules/@angular/platform-browser": {
-      "version": "20.3.17",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.17.tgz",
-      "integrity": "sha512-GA8pK+0F2/KGdYn5LMpLBrPTkQUwGjQE8Q+qsivOa150cK3OuD0po5PvYK58l+niGIVvm0wB1xGKTHTOiX/+4A==",
+      "version": "20.3.18",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-20.3.18.tgz",
+      "integrity": "sha512-q6s5rEN1yYazpHYp+k4pboXRzMsRB9auzTRBEhyXSGYxqzrnn3qHN0DqgsLC9WAdyhCgnIEMFA8kRT+W277DqQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.3.0"
@@ -699,9 +699,9 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/animations": "20.3.17",
-        "@angular/common": "20.3.17",
-        "@angular/core": "20.3.17"
+        "@angular/animations": "20.3.18",
+        "@angular/common": "20.3.18",
+        "@angular/core": "20.3.18"
       },
       "peerDependenciesMeta": {
         "@angular/animations": {
@@ -710,9 +710,9 @@
       }
     },
     "node_modules/@angular/platform-browser-dynamic": {
-      "version": "20.3.17",
-      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.17.tgz",
-      "integrity": "sha512-yTxFuGQ+z0J9khNIhfFZ+kkT7TOFb8kFZKyUz0DxHOmE0q/TEvNZoy3jXOs8xCBFf1+6BY0NqFNlPna+uw36FQ==",
+      "version": "20.3.18",
+      "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-20.3.18.tgz",
+      "integrity": "sha512-NyTobOGYVzGmPmtI+3lxMzxi0TbLq4SRNQ2ENEJAt6k2JnMmHBm483ppLRAM47nGlDdiraW0IX93EtYYNkiK3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -722,10 +722,10 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       },
       "peerDependencies": {
-        "@angular/common": "20.3.17",
-        "@angular/compiler": "20.3.17",
-        "@angular/core": "20.3.17",
-        "@angular/platform-browser": "20.3.17"
+        "@angular/common": "20.3.18",
+        "@angular/compiler": "20.3.18",
+        "@angular/core": "20.3.18",
+        "@angular/platform-browser": "20.3.18"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -944,23 +944,23 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-      "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/types": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-      "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1525,9 +1525,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1623,9 +1623,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1701,22 +1701,19 @@
       }
     },
     "node_modules/@gar/promise-retry": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.2.tgz",
-      "integrity": "sha512-Lm/ZLhDZcBECta3TmCQSngiQykFdfw+QtI1/GYMsZd4l3nG+P8WLB16XuS7WaBGLQ+9E+cOcWQsth9cayuGt8g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@gar/promise-retry/-/promise-retry-1.0.3.tgz",
+      "integrity": "sha512-GmzA9ckNokPypTg10pgpeHNQe7ph+iIKKmhKu3Ob9ANkswreCx7R3cKmY781K8QK3AqVL3xVh9A42JvIAbkkSA==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "retry": "^0.13.1"
-      },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
-      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
+      "version": "1.19.12",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
+      "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2159,6 +2156,17 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
       }
     },
@@ -2809,9 +2817,9 @@
       }
     },
     "node_modules/@npmcli/agent/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -2872,9 +2880,9 @@
       }
     },
     "node_modules/@npmcli/git/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -3770,9 +3778,9 @@
       ]
     },
     "node_modules/@rollup/wasm-node": {
-      "version": "4.59.0",
-      "resolved": "https://registry.npmjs.org/@rollup/wasm-node/-/wasm-node-4.59.0.tgz",
-      "integrity": "sha512-cKB/Pe05aJWQYw3UFS79Id+KVXdExBxWful0+CSl24z3ukwOgBSy6l39XZNwfm3vCh/fpUrAAs+T7PsJ6dC8NA==",
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/wasm-node/-/wasm-node-4.60.1.tgz",
+      "integrity": "sha512-FAfGj5Ferzyna11iUwGdkYus/Y9d/H75PEpsseP5DZOsEsyPvP/Q7mJiSXhUYSEmyfHPaZyC8EsJCjqzDbtcfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3790,14 +3798,14 @@
       }
     },
     "node_modules/@schematics/angular": {
-      "version": "20.3.19",
-      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.19.tgz",
-      "integrity": "sha512-LG8w+NhrrjWw14r1Xgw/pwPT/WlFgVo5vH8qQMpkMvLhPHGAt6nsaQEUYKot8mlpatMQK0yCrrsNPvLquBvD2A==",
+      "version": "20.3.22",
+      "resolved": "https://registry.npmjs.org/@schematics/angular/-/angular-20.3.22.tgz",
+      "integrity": "sha512-wXTdFaPIBnSSNj/m0kclvPCYQOc2EGTQN1+Q3j9RIghS9gKgPxI1unSfgieJldZWKzcl8+WdB2zUuDzE7tEshQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "20.3.19",
-        "@angular-devkit/schematics": "20.3.19",
+        "@angular-devkit/core": "20.3.22",
+        "@angular-devkit/schematics": "20.3.22",
         "jsonc-parser": "3.3.1"
       },
       "engines": {
@@ -3820,9 +3828,9 @@
       }
     },
     "node_modules/@sigstore/core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.1.0.tgz",
-      "integrity": "sha512-o5cw1QYhNQ9IroioJxpzexmPjfCe7gzafd2RY3qnMpxr4ZEja+Jad/U8sgFpaue6bOaF+z7RVkyKVV44FN+N8A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sigstore/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-kxHrDQ9YgfrWUSXU0cjsQGv8JykOFZQ9ErNKbFPWzk3Hgpwu8x2hHrQ9IdA8yl+j9RTLTC3sAF3Tdq1IQCP4oA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -3840,18 +3848,18 @@
       }
     },
     "node_modules/@sigstore/sign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.0.tgz",
-      "integrity": "sha512-Vx1RmLxLGnSUqx/o5/VsCjkuN5L7y+vxEEwawvc7u+6WtX2W4GNa7b9HEjmcRWohw/d6BpATXmvOwc78m+Swdg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@sigstore/sign/-/sign-4.1.1.tgz",
+      "integrity": "sha512-Hf4xglukg0XXQ2RiD5vSoLjdPe8OBUPA8XeVjUObheuDcWdYWrnH/BNmxZCzkAy68MzmNCxXLeurJvs6hcP2OQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "@gar/promise-retry": "^1.0.2",
         "@sigstore/bundle": "^4.0.0",
-        "@sigstore/core": "^3.1.0",
+        "@sigstore/core": "^3.2.0",
         "@sigstore/protobuf-specs": "^0.5.0",
-        "make-fetch-happen": "^15.0.3",
-        "proc-log": "^6.1.0",
-        "promise-retry": "^2.0.1"
+        "make-fetch-happen": "^15.0.4",
+        "proc-log": "^6.1.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -3868,9 +3876,9 @@
       }
     },
     "node_modules/@sigstore/tuf": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.1.tgz",
-      "integrity": "sha512-OPZBg8y5Vc9yZjmWCHrlWPMBqW5yd8+wFNl+thMdtcWz3vjVSoJQutF8YkrzI0SLGnkuFof4HSsWUhXrf219Lw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@sigstore/tuf/-/tuf-4.0.2.tgz",
+      "integrity": "sha512-TCAzTy0xzdP79EnxSjq9KQ3eaR7+FmudLC6eRKknVKZbV7ZNlGLClAAQb/HMNJ5n2OBNk2GT1tEmU0xuPr+SLQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -3966,13 +3974,23 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.3.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.5.tgz",
-      "integrity": "sha512-oX8xrhvpiyRCQkG1MFchB09f+cXftgIXb3a7UUa4Y3wpmZPw5tyZGTLWhlESOLq1Rq6oDlc8npVU2/9xiCuXMA==",
+      "version": "25.5.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.2.tgz",
+      "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4004,6 +4022,190 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.56.1.tgz",
@@ -4029,7 +4231,7 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/project-service": {
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
       "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
@@ -4051,7 +4253,7 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
       "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
@@ -4069,7 +4271,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/tsconfig-utils": {
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
       "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
@@ -4084,6 +4286,166 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
+      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.58.0",
+        "@typescript-eslint/types": "^8.58.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
+      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
+      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
@@ -4111,7 +4473,64 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/types": {
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
       "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
@@ -4125,7 +4544,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree": {
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
       "version": "8.56.1",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
       "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
@@ -4151,6 +4570,133 @@
       },
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
+      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
+      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.58.0",
+        "@typescript-eslint/tsconfig-utils": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/visitor-keys": "8.58.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
@@ -4184,16 +4730,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
-      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
+      "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.56.1",
-        "@typescript-eslint/types": "8.56.1",
-        "@typescript-eslint/typescript-estree": "8.56.1"
+        "@typescript-eslint/scope-manager": "8.58.0",
+        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/typescript-estree": "8.58.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4204,17 +4750,17 @@
       },
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.56.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
-      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "version": "8.58.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
+      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/types": "8.58.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4469,9 +5015,9 @@
       }
     },
     "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4546,9 +5092,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz",
-      "integrity": "sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==",
+      "version": "2.10.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.14.tgz",
+      "integrity": "sha512-fOVLPAsFTsQfuCkvahZkzq6nf8KvGWanlYoTh0SVA0A/PIUxQGU2AOZAoD95n2gFLVDW/jP6sbGLny95nmEuHA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -4624,9 +5170,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4650,9 +5196,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-      "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+      "version": "4.28.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
       "dev": true,
       "funding": [
         {
@@ -4670,11 +5216,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.9.0",
-        "caniuse-lite": "^1.0.30001759",
-        "electron-to-chromium": "^1.5.263",
-        "node-releases": "^2.0.27",
-        "update-browserslist-db": "^1.2.0"
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -4701,9 +5247,9 @@
       }
     },
     "node_modules/cacache": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.3.tgz",
-      "integrity": "sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw==",
+      "version": "20.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-20.0.4.tgz",
+      "integrity": "sha512-M3Lab8NPYlZU2exsL3bMVvMrMqgwCnMWfdZbK28bn3pK6APT/Te/I8hjRPNu1uwORY9a1eEQoifXbKPQMfMTOA==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -4716,8 +5262,7 @@
         "minipass-flush": "^1.0.5",
         "minipass-pipeline": "^1.2.4",
         "p-map": "^7.0.2",
-        "ssri": "^13.0.0",
-        "unique-filename": "^5.0.0"
+        "ssri": "^13.0.0"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -4742,9 +5287,9 @@
       }
     },
     "node_modules/cacache/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4793,9 +5338,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001777",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001777.tgz",
-      "integrity": "sha512-tmN+fJxroPndC74efCdp12j+0rk0RHwV5Jwa1zWaFVyw2ZxAuPeG8ZgWC3Wz7uSjT3qMRQ5XHZ4COgQmsCMJAQ==",
+      "version": "1.0.30001785",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001785.tgz",
+      "integrity": "sha512-blhOL/WNR+Km1RI/LCVAvA73xplXA7ZbjzI4YkMK9pa6T/P3F2GxjNpEkyw5repTw9IvkyrjyHpwjnhZ5FOvYQ==",
       "dev": true,
       "funding": [
         {
@@ -5160,13 +5705,16 @@
       }
     },
     "node_modules/copy-anything": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-2.0.6.tgz",
-      "integrity": "sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-3.0.5.tgz",
+      "integrity": "sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "is-what": "^3.14.1"
+        "is-what": "^4.1.8"
+      },
+      "engines": {
+        "node": ">=12.13"
       },
       "funding": {
         "url": "https://github.com/sponsors/mesqueeb"
@@ -5453,9 +6001,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.307",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.307.tgz",
-      "integrity": "sha512-5z3uFKBWjiNR44nFcYdkcXjKMbg5KXNdciu7mhTPo9tB7NbqSNP2sSnGR+fqknZSCwKkBN+oxiiajWs4dT6ORg==",
+      "version": "1.5.331",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
+      "integrity": "sha512-IbxXrsTlD3hRodkLnbxAPP4OuJYdWCeM3IOdT+CpcMoIwIoDfCmRpEtSPfwBXxVkg9xmBeY7Lz2Eo2TDn/HC3Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -5484,14 +6032,15 @@
       }
     },
     "node_modules/engine.io": {
-      "version": "6.6.5",
-      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.5.tgz",
-      "integrity": "sha512-2RZdgEbXmp5+dVbRm0P7HQUImZpICccJy7rN7Tv+SFa55pH+lxnuw6/K1ZxxBfHoYpSkHLAO92oa8O4SwFXA2A==",
+      "version": "6.6.6",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.6.tgz",
+      "integrity": "sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/cors": "^2.8.12",
         "@types/node": ">=10.0.0",
+        "@types/ws": "^8.5.12",
         "accepts": "~1.3.4",
         "base64id": "2.0.0",
         "cookie": "~0.7.2",
@@ -5856,9 +6405,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6102,9 +6651,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.0.tgz",
-      "integrity": "sha512-KJzBawY6fB9FiZGdE/0aftepZ91YlaGIrV8vgblRM3J8X+dHx/aiowJWwkx6LIGyuqGiANsjSwwrbb8mifOJ4Q==",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6395,9 +6944,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.0.tgz",
-      "integrity": "sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },
@@ -6647,9 +7196,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6787,9 +7336,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
-      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
+      "version": "4.12.10",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.10.tgz",
+      "integrity": "sha512-mx/p18PLy5og9ufies2GOSUqep98Td9q4i/EF6X7yJgAiIopxqdfIO3jbqsi3jRgTgw88jMDEzVKi+V2EF+27w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6810,9 +7359,9 @@
       }
     },
     "node_modules/hosted-git-info/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -7205,11 +7754,17 @@
       }
     },
     "node_modules/is-what": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/is-what/-/is-what-3.14.1.tgz",
-      "integrity": "sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==",
+      "version": "4.1.16",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-4.1.16.tgz",
+      "integrity": "sha512-ZhMwEosbFJkA0YhFnNDgTM4ZxDRsS6HqTo7qsZM08fehyRYIYa0yHu5R6mgo1n/8MgaPBXiPimPD77baVFYg+A==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
     },
     "node_modules/isbinaryfile": {
       "version": "4.0.10",
@@ -7336,9 +7891,9 @@
       "license": "MIT"
     },
     "node_modules/jose": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.0.tgz",
-      "integrity": "sha512-xsfE1TcSCbUdo6U07tR0mvhg0flGxU8tPLbF03mirl2ukGQENhUg4ubGYQnhVH0b5stLlPM+WOqDkEl1R1y5sQ==",
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -7547,9 +8102,9 @@
       "license": "MIT"
     },
     "node_modules/karma-coverage/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7675,9 +8230,9 @@
       }
     },
     "node_modules/karma/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
+      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7829,9 +8384,9 @@
       "license": "MIT"
     },
     "node_modules/karma/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7996,22 +8551,20 @@
       }
     },
     "node_modules/less": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/less/-/less-4.5.1.tgz",
-      "integrity": "sha512-UKgI3/KON4u6ngSsnDADsUERqhZknsVZbnuzlRZXLQCmfC/MDld42fTydUE9B+Mla1AL6SJ/Pp6SlEFi/AVGfw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/less/-/less-4.6.4.tgz",
+      "integrity": "sha512-OJmO5+HxZLLw0RLzkqaNHzcgEAQG7C0y3aMbwtCzIUFZsLMNNq/1IdAdHEycQ58CwUO3jPTHmoN+tE5I7FQxNg==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "copy-anything": "^2.0.1",
-        "parse-node-version": "^1.0.1",
-        "tslib": "^2.3.0"
+        "copy-anything": "^3.0.5",
+        "parse-node-version": "^1.0.1"
       },
       "bin": {
         "lessc": "bin/lessc"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       },
       "optionalDependencies": {
         "errno": "^0.1.1",
@@ -8393,14 +8946,15 @@
       }
     },
     "node_modules/make-fetch-happen": {
-      "version": "15.0.4",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.4.tgz",
-      "integrity": "sha512-vM2sG+wbVeVGYcCm16mM3d5fuem9oC28n436HjsGO3LcxoTI8LNVa4rwZDn3f76+cWyT4GGJDxjTYU1I2nr6zw==",
+      "version": "15.0.5",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-15.0.5.tgz",
+      "integrity": "sha512-uCbIa8jWWmQZt4dSnEStkVC6gdakiinAm4PiGsywIkguF0eWMdcjDz0ECYhUolFU3pFLOev9VNPCEygydXnddg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
         "@npmcli/agent": "^4.0.0",
+        "@npmcli/redact": "^4.0.0",
         "cacache": "^20.0.1",
         "http-cache-semantics": "^4.1.1",
         "minipass": "^7.0.2",
@@ -8496,9 +9050,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -8562,13 +9116,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
-      "integrity": "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -8629,11 +9183,11 @@
       }
     },
     "node_modules/minipass-flush": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
-      "integrity": "sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -8751,9 +9305,9 @@
       "license": "MIT"
     },
     "node_modules/msgpackr": {
-      "version": "1.11.8",
-      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.8.tgz",
-      "integrity": "sha512-bC4UGzHhVvgDNS7kn9tV8fAucIYUBuGojcaLiz7v+P63Lmtm0Xeji8B/8tYKddALXxJLpwIeBmUN3u64C4YkRA==",
+      "version": "1.11.9",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-1.11.9.tgz",
+      "integrity": "sha512-FkoAAyyA6HM8wL882EcEyFZ9s7hVADSwG9xrVx3dxxNQAtgADTrJoEWivID82Iv1zWDsv/OtbrrcZAzGzOMdNw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -8821,9 +9375,9 @@
       "license": "MIT"
     },
     "node_modules/needle": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/needle/-/needle-3.3.1.tgz",
-      "integrity": "sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+      "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -9008,9 +9562,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.37",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+      "integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
       "dev": true,
       "license": "MIT"
     },
@@ -9552,9 +10106,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.2.6",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
-      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -9562,9 +10116,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -9590,9 +10144,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -9773,16 +10327,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/promise-retry/node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
       }
     },
     "node_modules/proxy-addr": {
@@ -9984,9 +10528,9 @@
       }
     },
     "node_modules/retry": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
-      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10074,27 +10618,37 @@
       }
     },
     "node_modules/rollup-plugin-dts": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.3.0.tgz",
-      "integrity": "sha512-d0UrqxYd8KyZ6i3M2Nx7WOMy708qsV/7fTHMHxCMCBOAe3V/U7OMPu5GkX8hC+cmkHhzGnfeYongl1IgiooddA==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-dts/-/rollup-plugin-dts-6.4.1.tgz",
+      "integrity": "sha512-l//F3Zf7ID5GoOfLfD8kroBjQKEKpy1qfhtAdnpibFZMffPaylrg1CoDC2vGkPeTeyxUe4bVFCln2EFuL7IGGg==",
       "dev": true,
       "license": "LGPL-3.0-only",
       "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "@jridgewell/sourcemap-codec": "^1.5.5",
+        "convert-source-map": "^2.0.0",
         "magic-string": "^0.30.21"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/Swatinem"
       },
       "optionalDependencies": {
-        "@babel/code-frame": "^7.27.1"
+        "@babel/code-frame": "^7.29.0"
       },
       "peerDependencies": {
         "rollup": "^3.29.4 || ^4",
-        "typescript": "^4.5 || ^5.0"
+        "typescript": "^4.5 || ^5.0 || ^6.0"
       }
+    },
+    "node_modules/rollup-plugin-dts/node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/rollup-plugin-dts/node_modules/magic-string": {
       "version": "0.30.21",
@@ -10203,9 +10757,9 @@
       }
     },
     "node_modules/sax": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.5.0.tgz",
-      "integrity": "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "optional": true,
@@ -10492,9 +11046,9 @@
       }
     },
     "node_modules/socket.io-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.5.tgz",
-      "integrity": "sha512-bPMmpy/5WWKHea5Y/jYAP6k74A+hvmRCQaJuJB6I/ML5JZq/KfNieUVo/3Mh7SAqn7TyFdIo6wqYHInG1MU1bQ==",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10831,9 +11385,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.11",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.11.tgz",
-      "integrity": "sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==",
+      "version": "7.5.13",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.13.tgz",
+      "integrity": "sha512-tOG/7GyXpFevhXVh8jOPJrmtRpOTsYqUIkVdVooZYJS/z8WhfQUX8RJILmeuJNinGAMSu1veBr4asSHFt5/hng==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -10931,9 +11485,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -11030,6 +11584,190 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/project-service": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.56.1.tgz",
+      "integrity": "sha512-TAdqQTzHNNvlVFfR+hu2PDJrURiwKsUvxFn1M0h95BB8ah5jejas08jUWG4dBA68jDMI988IvtfdAI53JzEHOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.56.1",
+        "@typescript-eslint/types": "^8.56.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.56.1.tgz",
+      "integrity": "sha512-YAi4VDKcIZp0O4tz/haYKhmIDZFEUPOreKbfdAN3SzUDMcPhJ8QI99xQXqX+HoUVq8cs85eRKnD+rne2UAnj2w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.56.1.tgz",
+      "integrity": "sha512-qOtCYzKEeyr3aR9f28mPJqBty7+DBqsdd63eO0yyDwc6vgThj2UjWfJIcsFeSucYydqcuudMOprZ+x1SpF3ZuQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/types": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.56.1.tgz",
+      "integrity": "sha512-dbMkdIUkIkchgGDIv7KLUpa0Mda4IYjo4IAMJUZ+3xNoUXxMsk9YtKpTHSChRS85o+H9ftm51gsK1dZReY9CVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.56.1.tgz",
+      "integrity": "sha512-qzUL1qgalIvKWAf9C1HpvBjif+Vm6rcT5wZd4VoMb9+Km3iS3Cv9DY6dMRMDtPnwRAFyAi7YXJpTIEXLvdfPxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.56.1",
+        "@typescript-eslint/tsconfig-utils": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/visitor-keys": "8.56.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.56.1.tgz",
+      "integrity": "sha512-HPAVNIME3tABJ61siYlHzSWCGtOoeP2RTIaHXFMPqjrQKCGB9OgUVdiNgH7TJS2JNIQ5qQ4RsAUDuGaGme/KOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.56.1",
+        "@typescript-eslint/types": "8.56.1",
+        "@typescript-eslint/typescript-estree": "8.56.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.56.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.56.1.tgz",
+      "integrity": "sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.56.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/typescript-eslint/node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
     "node_modules/ua-parser-js": {
       "version": "0.7.41",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.41.tgz",
@@ -11063,32 +11801,6 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/unique-filename": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-5.0.0.tgz",
-      "integrity": "sha512-2RaJTAvAb4owyjllTfXzFClJ7WsGxlykkPvCr9pA//LD9goVq+m4PPAeBgNodGZ7nSrntT/auWpJ6Y5IFXcfjg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "unique-slug": "^6.0.0"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/unique-slug": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-6.0.0.tgz",
-      "integrity": "sha512-4Lup7Ezn8W3d52/xBhZBVdx323ckxa7DEvd9kPQHppTkLoJXw6ltrBCyj5pnrxj0qKDxYMJ56CoxNuFCscdTiw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "imurmurhash": "^0.1.4"
-      },
-      "engines": {
-        "node": "^20.17.0 || >=22.9.0"
-      }
     },
     "node_modules/universalify": {
       "version": "2.0.1",
@@ -11522,13 +12234,13 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "dev": true,
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     },
     "node_modules/zone.js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-awesome",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "private": false,
   "description": "Angular 20+ wrappers for the Web Awesome 3.5.x web components framework",
   "keywords": [
@@ -32,9 +32,9 @@
   "es2022": "dist/angular-awesome/fesm2022/angular-awesome.js",
   "typings": "dist/angular-awesome/index.d.ts",
   "peerDependencies": {
-    "@angular/common": "^20.3.17",
-    "@angular/core": "^20.3.17",
-    "@angular/forms": "^20.3.17"
+    "@angular/common": ">=20.0.0",
+    "@angular/core": ">=20.0.0",
+    "@angular/forms": ">=20.0.0"
   },
   "devDependencies": {
     "@angular/build": "^20.3.19",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-awesome",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "private": false,
   "description": "Angular 20+ wrappers for the Web Awesome 3.5.x web components framework",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "angular-awesome",
-  "version": "3.5.2",
+  "version": "3.6.0",
   "private": false,
-  "description": "Angular 20+ wrappers for the Web Awesome 3.5.x web components framework",
+  "description": "Angular 20+ wrappers for the Web Awesome 3.6.x web components framework",
   "keywords": [
     "angular",
     "web-awesome",

--- a/skills/angular-awesome/SKILL.md
+++ b/skills/angular-awesome/SKILL.md
@@ -7,7 +7,7 @@ metadata:
 
 # Angular Awesome
 
-Angular 20+ standalone directives wrapping Web Awesome 3.3.x web components. Every `<wa-*>` tag has a corresponding `Wa*Directive` or `Wa*Component` that binds attributes as `@Input()` properties, emits custom events as `@Output()`, and exposes `nativeElement` for direct access.
+Angular 20+ standalone directives wrapping Web Awesome 3.6.x web components. Every `<wa-*>` tag has a corresponding `Wa*Directive` or `Wa*Component` that binds attributes as `@Input()` properties, emits custom events as `@Output()`, and exposes `nativeElement` for direct access.
 
 ## Quick Start
 
@@ -34,7 +34,7 @@ export class MyComponent { save() {} }
 
 ```ts
 type VariantToken = 'brand' | 'neutral' | 'success' | 'warning' | 'danger' | 'inherit';
-type SizeToken    = 'small' | 'medium' | 'large' | 'inherit';
+type SizeToken    = 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' | 'inherit';
 type Appearance   = 'accent' | 'filled' | 'outlined' | 'plain' | 'filled-outlined';
 ```
 

--- a/src/directives/button/button.directive.ts
+++ b/src/directives/button/button.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, ElementRef, EventEmitter, Input, OnInit, Output, Renderer2, OnChanges, SimpleChanges, inject } from '@angular/core';
-import { Appearance, normalizeAppearance } from '../../types/tokens';
+import { Appearance, normalizeAppearance, SizeToken } from '../../types/tokens';
 
 /**
  * WaButtonDirective
@@ -28,7 +28,7 @@ export class WaButtonDirective implements OnInit, OnChanges {
    * Strictly typed to known tokens only.
    */
   @Input() appearance?: Appearance;
-  @Input() size?: 'small' | 'medium' | 'large' | 'inherit' | string;
+  @Input() size?: SizeToken | string;
 
   // Boolean inputs
   @Input() pill?: boolean | string;

--- a/src/directives/dropdown/dropdown.directive.ts
+++ b/src/directives/dropdown/dropdown.directive.ts
@@ -1,5 +1,6 @@
 import { Directive, ElementRef, EventEmitter, forwardRef, Input, OnInit, OnChanges, SimpleChanges, Output, Renderer2, inject } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { SizeToken } from '../../types/tokens';
 
 /**
  * Type definition for dropdown placement options
@@ -43,7 +44,7 @@ export class WaDropdownDirective implements OnInit, OnChanges, ControlValueAcces
   // Structural inputs
   @Input() placement?: DropdownPlacement | string;
   @Input() open?: boolean | string;
-  @Input() size?: 'small' | 'medium' | 'large' | string;
+  @Input() size?: SizeToken | string;
   @Input() disabled?: boolean | string;
   @Input() stayOpenOnSelect?: boolean | string;
   @Input() containingElement?: HTMLElement;

--- a/src/directives/file-input/file-input.directive.ts
+++ b/src/directives/file-input/file-input.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, EventEmitter, Input, OnChanges, AfterViewInit, Output, Renderer2 } from '@angular/core';
+import {SizeToken} from '../../types/tokens';
 
 @Directive({
   selector: 'wa-file-input',
@@ -8,7 +9,7 @@ export class WaFileInputDirective implements AfterViewInit, OnChanges {
   constructor(private host: ElementRef<HTMLElement>, private renderer: Renderer2) {}
 
   // Properties
-  @Input() size: 'small' | 'medium' | 'large' | string = 'medium';
+  @Input() size: SizeToken | string = 'medium';
   @Input() label?: string;
   @Input() hint?: string;
   @Input() multiple?: boolean | string;

--- a/src/directives/form-validation/form-errors.spec.ts
+++ b/src/directives/form-validation/form-errors.spec.ts
@@ -516,7 +516,7 @@ describe('WaSelectWrapperComponent — Form Validation', () => {
 @Component({
   template: `
     <form [formGroup]="form">
-      <wa-switch waSwitch formControlName="notifications" [required]="true">Notifications</wa-switch>
+      <wa-switch formControlName="notifications" [required]="true">Notifications</wa-switch>
     </form>
   `,
   standalone: true,
@@ -532,7 +532,7 @@ class SwitchReactiveHost {
 @Component({
   template: `
     <form #f="ngForm">
-      <wa-switch waSwitch [(ngModel)]="notifications" name="notifications" required>Notifications</wa-switch>
+      <wa-switch [(ngModel)]="notifications" name="notifications" required>Notifications</wa-switch>
     </form>
   `,
   standalone: true,
@@ -2184,7 +2184,7 @@ describe('WaSelectWrapperComponent — Extended Coverage', () => {
 @Component({
   template: `
     <form [formGroup]="form">
-      <wa-switch waSwitch formControlName="agree" [required]="true">Agree</wa-switch>
+      <wa-switch formControlName="agree" [required]="true">Agree</wa-switch>
     </form>
   `,
   standalone: true,

--- a/src/directives/input/input.directive.ts
+++ b/src/directives/input/input.directive.ts
@@ -1,6 +1,6 @@
 import { Directive, DoCheck, ElementRef, EventEmitter, forwardRef, Injector, Input, OnInit, OnChanges, SimpleChanges, Output, Renderer2, inject } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR, Validator, NG_VALIDATORS, AbstractControl, ValidationErrors, NgControl } from '@angular/forms';
-import { Appearance, normalizeAppearance } from '../../types/tokens';
+import { Appearance, normalizeAppearance, SizeToken } from '../../types/tokens';
 import { syncFormValidationState } from '../shared/form-validation-state';
 
 /**
@@ -41,7 +41,7 @@ export class WaInputDirective implements OnInit, OnChanges, DoCheck, ControlValu
   // Core input attributes
   @Input() type?: string;
   @Input() value?: string | number | null;
-  @Input() size?: 'small' | 'medium' | 'large' | 'inherit' | string;
+  @Input() size?: SizeToken | string;
   @Input() appearance?: Appearance | string;
   @Input() pill?: boolean | string;
   @Input() label?: string;

--- a/src/directives/number-input/number-input.directive.ts
+++ b/src/directives/number-input/number-input.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, EventEmitter, Input, OnChanges, AfterViewInit, Output, Renderer2 } from '@angular/core';
+import {SizeToken} from '../../types/tokens';
 
 @Directive({
   selector: 'wa-number-input',
@@ -10,7 +11,7 @@ export class WaNumberInputDirective implements AfterViewInit, OnChanges {
   // Properties (subset mapped from llms.txt)
   @Input() value?: string | number;
   @Input() defaultValue?: string | null;
-  @Input() size: 'small' | 'medium' | 'large' | string = 'medium';
+  @Input() size: SizeToken | string = 'medium';
   @Input() appearance: 'filled' | 'outlined' | 'filled-outlined' | string = 'outlined';
   @Input() pill?: boolean | string;
   @Input() label?: string;

--- a/src/directives/switch/switch.directive.spec.ts
+++ b/src/directives/switch/switch.directive.spec.ts
@@ -1,13 +1,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Component } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { WaSwitchDirective } from './switch.directive';
+import { WaSwitchDirective, WaSwitchEvent } from './switch.directive';
 
 // Create a test host component for the switch directive
 @Component({
   template: `
     <wa-switch
-      waSwitch
       [disabled]="disabled"
       [hint]="hint"
       [size]="size"
@@ -261,5 +260,24 @@ describe('WaSwitchDirective', () => {
     // Simulate blur event
     switchElement.dispatchEvent(new FocusEvent('wa-blur'));
     expect(hostComponent.blurEventCalled).toBe(true);
+  });
+
+  it('should emit WaSwitchEvent with target.checked accessible', () => {
+    // Set the switch to checked so target.checked is true
+    (switchElement as any).checked = true;
+    switchElement.setAttribute('checked', '');
+    switchElement.dispatchEvent(new Event('wa-change'));
+    hostFixture.detectChanges();
+
+    // The changeEvent output emits WaSwitchEvent which has target.checked typed
+    // Verify the event was emitted (the type safety is compile-time)
+    expect(hostComponent.changeEventCalled).toBeTrue();
+  });
+
+  it('WaSwitchEvent interface should be importable and usable as a type', () => {
+    // This test verifies the type exists at runtime as an interface contract
+    const fakeEvent = { target: { checked: true, value: 'on' } } as unknown as WaSwitchEvent;
+    expect(fakeEvent.target.checked).toBeTrue();
+    expect(fakeEvent.target.value).toBe('on');
   });
 });

--- a/src/directives/switch/switch.directive.ts
+++ b/src/directives/switch/switch.directive.ts
@@ -4,6 +4,15 @@ import { SizeToken } from '../../types/tokens';
 import { syncFormValidationState } from '../shared/form-validation-state';
 
 /**
+ * Typed event interface for wa-switch change/input events.
+ * Provides type-safe access to `target.checked` so consumers
+ * can use `$event.target.checked` in templates without TS errors.
+ */
+export interface WaSwitchEvent extends Event {
+  target: EventTarget & { checked: boolean; value: string };
+}
+
+/**
  * WaSwitchDirective
  *
  * Angular wrapper for the <wa-switch> Web Component that allows declarative usage,
@@ -16,7 +25,7 @@ import { syncFormValidationState } from '../shared/form-validation-state';
  * - Supports ngModel for form integration
  */
 @Directive({
-  selector: 'wa-switch[waSwitch]',
+  selector: 'wa-switch',
   standalone: true,
   providers: [
     {
@@ -63,8 +72,8 @@ export class WaSwitchDirective implements OnInit, OnChanges, DoCheck, ControlVal
   @Input() width?: string;
 
   // Event outputs
-  @Output('wa-change') changeEvent = new EventEmitter<Event>();
-  @Output('wa-input') inputEvent = new EventEmitter<Event>();
+  @Output('wa-change') changeEvent = new EventEmitter<WaSwitchEvent>();
+  @Output('wa-input') inputEvent = new EventEmitter<WaSwitchEvent>();
   @Output('wa-focus') focusEvent = new EventEmitter<FocusEvent>();
   @Output('wa-blur') blurEvent = new EventEmitter<FocusEvent>();
   @Output() checkedChange = new EventEmitter<boolean>();
@@ -89,7 +98,7 @@ export class WaSwitchDirective implements OnInit, OnChanges, DoCheck, ControlVal
 
     // Set up event listeners
     const forwardInput = (event: Event) => {
-      this.inputEvent.emit(event);
+      this.inputEvent.emit(event as WaSwitchEvent);
       const target = event.target as HTMLInputElement;
       this.onChange(target.checked);
       this.checkedChange.emit(target.checked);
@@ -99,7 +108,7 @@ export class WaSwitchDirective implements OnInit, OnChanges, DoCheck, ControlVal
     this.renderer.listen(nativeEl, 'wa-input', forwardInput);
 
     const forwardChange = (event: Event) => {
-      this.changeEvent.emit(event);
+      this.changeEvent.emit(event as WaSwitchEvent);
       const target = event.target as HTMLInputElement;
       this.onChange(!!target.checked);
       this.checkedChange.emit(!!target.checked);

--- a/src/directives/switch/switch.example.md
+++ b/src/directives/switch/switch.example.md
@@ -3,52 +3,51 @@
 ## Basic Usage
 
 ```html
-<wa-switch waSwitch></wa-switch>
+<wa-switch></wa-switch>
 ```
 
 ## Disabled State
 
 ```html
-<wa-switch waSwitch disabled></wa-switch>
+<wa-switch disabled></wa-switch>
 ```
 
 ## With Hint Text
 
 ```html
-<wa-switch waSwitch hint="Enable feature"></wa-switch>
+<wa-switch hint="Enable feature"></wa-switch>
 ```
 
 ## Different Sizes
 
 ```html
 <!-- Small size -->
-<wa-switch waSwitch size="small"></wa-switch>
+<wa-switch size="small"></wa-switch>
 
 <!-- Medium size (default) -->
-<wa-switch waSwitch size="medium"></wa-switch>
+<wa-switch size="medium"></wa-switch>
 
 <!-- Large size -->
-<wa-switch waSwitch size="large"></wa-switch>
+<wa-switch size="large"></wa-switch>
 ```
 
 ## Custom Styling
 
 ```html
 <!-- Custom background color -->
-<wa-switch waSwitch [backgroundColor]="'#e0e0e0'" [backgroundColorChecked]="'#4CAF50'"></wa-switch>
+<wa-switch [backgroundColor]="'#e0e0e0'" [backgroundColorChecked]="'#4CAF50'"></wa-switch>
 
 <!-- Custom border -->
-<wa-switch waSwitch [borderColor]="'#999'" [borderColorChecked]="'#2196F3'" [borderWidth]="'2px'" [borderStyle]="'solid'"></wa-switch>
+<wa-switch [borderColor]="'#999'" [borderColorChecked]="'#2196F3'" [borderWidth]="'2px'" [borderStyle]="'solid'"></wa-switch>
 
 <!-- Custom thumb -->
-<wa-switch waSwitch [thumbColor]="'#fff'" [thumbColorChecked]="'#fff'" [thumbSize]="'16px'" [thumbShadow]="'0 0 4px rgba(0,0,0,0.3)'"></wa-switch>
+<wa-switch [thumbColor]="'#fff'" [thumbColorChecked]="'#fff'" [thumbSize]="'16px'" [thumbShadow]="'0 0 4px rgba(0,0,0,0.3)'"></wa-switch>
 
 <!-- Custom dimensions -->
-<wa-switch waSwitch [width]="'60px'" [height]="'30px'"></wa-switch>
+<wa-switch [width]="'60px'" [height]="'30px'"></wa-switch>
 
 <!-- Combined custom styling -->
 <wa-switch 
-  waSwitch 
   [backgroundColor]="'#f0f0f0'" 
   [backgroundColorChecked]="'#673AB7'" 
   [borderColor]="'#ccc'" 
@@ -75,12 +74,12 @@ import { WaSwitchDirective } from '@angular-awesome/directives/switch';
   selector: 'app-switch-demo',
   template: `
     <div class="form-group">
-      <wa-switch waSwitch [(ngModel)]="isEnabled" hint="Enable feature"></wa-switch>
+      <wa-switch [(ngModel)]="isEnabled" hint="Enable feature"></wa-switch>
       <p>Feature is {{ isEnabled ? 'enabled' : 'disabled' }}</p>
     </div>
     
     <div class="form-group">
-      <wa-switch waSwitch [(ngModel)]="darkMode" hint="Dark mode"></wa-switch>
+      <wa-switch [(ngModel)]="darkMode" hint="Dark mode"></wa-switch>
       <p>Dark mode is {{ darkMode ? 'on' : 'off' }}</p>
     </div>
   `,
@@ -103,7 +102,6 @@ import { WaSwitchDirective } from '@angular-awesome/directives/switch';
   selector: 'app-switch-events-demo',
   template: `
     <wa-switch 
-      waSwitch 
       [hint]="'Notifications'"
       (changeEvent)="onSwitchChange($event)"
       (inputEvent)="onSwitchInput($event)"
@@ -157,15 +155,15 @@ import { WaSwitchDirective } from '@angular-awesome/directives/switch';
   template: `
     <form [formGroup]="settingsForm" (ngSubmit)="onSubmit()">
       <div class="form-group">
-        <wa-switch waSwitch formControlName="notifications" hint="Enable notifications"></wa-switch>
+        <wa-switch formControlName="notifications" hint="Enable notifications"></wa-switch>
       </div>
       
       <div class="form-group">
-        <wa-switch waSwitch formControlName="darkMode" hint="Dark mode"></wa-switch>
+        <wa-switch formControlName="darkMode" hint="Dark mode"></wa-switch>
       </div>
       
       <div class="form-group">
-        <wa-switch waSwitch formControlName="autoSave" hint="Auto-save" [disabled]="!settingsForm.get('notifications')?.value"></wa-switch>
+        <wa-switch formControlName="autoSave" hint="Auto-save" [disabled]="!settingsForm.get('notifications')?.value"></wa-switch>
         <p class="hint">Auto-save requires notifications to be enabled</p>
       </div>
       

--- a/src/directives/switch/switch.rules.md
+++ b/src/directives/switch/switch.rules.md
@@ -4,7 +4,7 @@
 
 ### Selector
 
-`waSwitch`
+`wa-switch`
 
 ### Purpose
 
@@ -13,7 +13,7 @@ Wraps the `<wa-switch>` Web Component to expose Angular-style inputs/outputs and
 ### Usage
 
 ```html
-<wa-switch waSwitch [(ngModel)]="checked" [disabled]="isDisabled" hint="Toggle feature" size="medium">
+<wa-switch [(ngModel)]="checked" [disabled]="isDisabled" hint="Toggle feature" size="medium">
   Enable Feature
 </wa-switch>
 ```
@@ -75,7 +75,6 @@ This directive supports `ngModel` two-way binding. The `ngModel` value controls 
 ```html
 <form #form="ngForm">
   <wa-switch
-    waSwitch
     name="newsletter"
     [(ngModel)]="model.newsletter"
     hint="Receive monthly updates"

--- a/src/directives/toast/toast-item.directive.ts
+++ b/src/directives/toast/toast-item.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, Renderer2, inject } from '@angular/core';
+import { SizeToken } from '../../types/tokens';
 
 /**
  * WaToastItemDirective
@@ -23,7 +24,7 @@ export class WaToastItemDirective implements OnInit, OnChanges, OnDestroy {
   @Input() variant?: 'brand' | 'success' | 'warning' | 'danger' | 'neutral' | string;
 
   /** The toast item's size. */
-  @Input() size?: 'small' | 'medium' | 'large' | string;
+  @Input() size?: SizeToken | string;
 
   /**
    * The length of time in milliseconds before the toast item is automatically dismissed.

--- a/src/directives/toast/toast.directive.ts
+++ b/src/directives/toast/toast.directive.ts
@@ -1,4 +1,5 @@
 import { Directive, ElementRef, Input, OnInit, OnChanges, SimpleChanges, Renderer2, inject } from '@angular/core';
+import { SizeToken } from '../../types/tokens';
 
 /**
  * WaToastDirective
@@ -82,7 +83,7 @@ export interface WaToastNativeElement extends HTMLElement {
  */
 export interface ToastCreateOptions {
   variant?: 'brand' | 'success' | 'warning' | 'danger' | 'neutral';
-  size?: 'small' | 'medium' | 'large';
+  size?: SizeToken;
   duration?: number;
   icon?: string;
 }

--- a/src/types/tokens.ts
+++ b/src/types/tokens.ts
@@ -3,8 +3,8 @@
 // Core variants supported across components
 export type VariantToken = 'brand' | 'neutral' | 'success' | 'warning' | 'danger' | 'inherit';
 
-// Common control sizes
-export type SizeToken = 'small' | 'medium' | 'large' | 'inherit';
+// Common control sizes (Web Awesome 3.6.0 added shorthand tokens xs/s/m/l/xl)
+export type SizeToken = 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' | 'inherit';
 
 // Visual appearance tokens (Web Awesome 3.0.0)
 // Note: 'filled-outlined' replaces the former space-delimited 'filled outlined'


### PR DESCRIPTION
This pull request updates the Angular Awesome library to align with Web Awesome 3.6.0, introducing expanded size token support, updating documentation, and improving compatibility with future Angular versions. The most impactful changes are the addition of new shorthand size tokens, the default size update, and simplification of the `wa-switch` directive usage. Several documentation and code examples have been updated to reflect these changes.

**Component API and Compatibility Updates:**

* Expanded the `SizeToken` type to support shorthand tokens `'xs' | 's' | 'm' | 'l' | 'xl'` in addition to legacy values, and updated all component `size` inputs to accept these new values. The default size is now `'m'` instead of `'medium'`, matching Web Awesome 3.6.0. Legacy values remain supported for backward compatibility. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R34) `src/types/tokens.ts` [[2]](diffhunk://#diff-d835c7919e04d7349ee5467420de34067740d50a2feb3ed44767052f1f5633f1L37-R37) `src/directives/*/*.directive.ts` [[3]](diffhunk://#diff-e208b4476a3483d7fd59c29ec4e6a8c57b36fc05c100662d55b59de4b07f1a7eL2-R2) [[4]](diffhunk://#diff-e208b4476a3483d7fd59c29ec4e6a8c57b36fc05c100662d55b59de4b07f1a7eL31-R31) [[5]](diffhunk://#diff-adeb63cb64d091abae8b676c6cbb7e899370e5f9491d92a0c3460268366e912aR3) [[6]](diffhunk://#diff-adeb63cb64d091abae8b676c6cbb7e899370e5f9491d92a0c3460268366e912aL46-R47) [[7]](diffhunk://#diff-1836025622e90331b75209c4e50eb53b98860f1f143a8850dc1e4696332d8388R2) [[8]](diffhunk://#diff-1836025622e90331b75209c4e50eb53b98860f1f143a8850dc1e4696332d8388L11-R12) [[9]](diffhunk://#diff-00777c9bbccface6f022d96ae1e69abb733afb2b35c2e4eb1b0cdbe5c1689cbaL3-R3) [[10]](diffhunk://#diff-00777c9bbccface6f022d96ae1e69abb733afb2b35c2e4eb1b0cdbe5c1689cbaL44-R44) [[11]](diffhunk://#diff-fbc25baf3d1340969f84e83c898ae87365071dcd4b873877b64b05053973ab57R2)
* Updated peer dependencies for `@angular/common`, `@angular/core`, and `@angular/forms` to `>=20.0.0`, ensuring compatibility with Angular 21+ and future versions. (`package.json` [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L35-R37) `CHANGELOG.md` [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R34) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR236) `README.md` [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L27-R27)

**Directive and Usage Simplification:**

* The `wa-switch` directive no longer requires the `waSwitch` attribute—simply use `<wa-switch>`. Updated all documentation, code examples, and tests to remove the redundant attribute. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R34) `docs/components/switch.html` [[2]](diffhunk://#diff-a1685891723f0cf238cd3d943872712d5e812bb66efe8310474ce1d04d02db29L106-R146) [[3]](diffhunk://#diff-a1685891723f0cf238cd3d943872712d5e812bb66efe8310474ce1d04d02db29L164-R175) [[4]](diffhunk://#diff-a1685891723f0cf238cd3d943872712d5e812bb66efe8310474ce1d04d02db29L189-R195) [[5]](diffhunk://#diff-a1685891723f0cf238cd3d943872712d5e812bb66efe8310474ce1d04d02db29L239-R254) `src/directives/form-validation/form-errors.spec.ts` [[6]](diffhunk://#diff-67ea8692603de5b2cf2d1bcc8eef4ff6365cd91c8bebd80e5e5e34524fb29f0fL519-R519) [[7]](diffhunk://#diff-67ea8692603de5b2cf2d1bcc8eef4ff6365cd91c8bebd80e5e5e34524fb29f0fL535-R535) [[8]](diffhunk://#diff-67ea8692603de5b2cf2d1bcc8eef4ff6365cd91c8bebd80e5e5e34524fb29f0fL2187-R2187)

**Documentation and Metadata:**

* Updated `README.md`, `SKILL.md`, and package metadata to reflect support for Web Awesome 3.6.x, TypeScript 5.9, and the new size tokens. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R7) [[2]](diffhunk://#diff-d835c7919e04d7349ee5467420de34067740d50a2feb3ed44767052f1f5633f1L10-R10) `package.json` [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R5)
* Added and updated changelog entries for versions 3.5.1, 3.5.2, and 3.6.0, documenting all notable changes and compatibility notes. (`CHANGELOG.md` [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR7-R34) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR236)

No breaking changes were introduced; all updates are backward compatible. Existing usages with legacy size values and the `waSwitch` attribute will continue to work.