### PR TITLE
Release 3.7.0 - Web Awesome 3.7.0 Alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project will be documented in this file.
 The format is based on Keep a Changelog and this project adheres to Semantic Versioning.
 
 
+## [3.7.0] - 2026-05-17
+### Added
+- **wa-video:** New `WaVideoDirective` wrapping the `<wa-video>` web component with full playback control:
+  - String inputs: `controls` (`'none' | 'standard' | 'full'`), `src`, `poster`, `title`, `thumbnails`, `preload`, `iconLibrary`
+  - Boolean inputs: `playing`, `muted`, `autoplay`, `loop`, `autoplayMuted`, `autoplayOnVisible`
+  - Numeric inputs: `volume`, `duration`, `currentTime`
+  - Event outputs: `waPlay` / `play`, `waPause` / `pause`, `waTimeupdate` / `timeupdate`, `waVolumechange` / `volumechange`, `waError` / `error`, `waEnded` / `ended`, `waLoadedmetadata` / `loadedmetadata`
+  - Methods: `play()`, `pause()`, `togglePlay()`, `toggleMute()`, `seek(time)`, `setVolume(volume)`, `setPlaybackRate(rate)`, `requestFullscreen()`, `exitFullscreen()`, `getVideoElement()`, `getState()`
+- **wa-video-playlist:** New `WaVideoPlaylistDirective` wrapping the `<wa-video-playlist>` web component:
+  - String inputs: `controls` (`'none' | 'standard' | 'full'`), `iconLibrary`
+  - Event output: `waVideoChange` / `wa-video-change` — emitted when the active video changes
+  - Methods: `next()`, `previous()`, `goTo(index)`
+- **wa-copy-button:** New `tooltip` input (`'full' | 'copy' | 'none'`, default `'full'`) — controls built-in tooltip behavior. `full` shows on hover/focus and during feedback; `copy` only shows during feedback; `none` disables tooltip entirely.
+- Both video directives exported from the public API surface.
+- Unit tests for both video directives and updated copy-button tests.
+- Rules and example documentation for both video components.
+
+### Changed
+- **wa-copy-button:** CSS parts updated — removed deprecated `tooltip__base`, `tooltip__base__popup`, `tooltip__base__arrow`, `tooltip__body` parts; replaced with single `feedback` part.
+- Updated `llms.txt` to Web Awesome 3.7.0.
+
+### Notes
+- This release aligns Angular Awesome with the **Web Awesome 3.7.0** component specification.
+- 2 new components added (`wa-video`, `wa-video-playlist`), 1 component updated (`wa-copy-button`). No breaking changes to the Angular API.
+
+
 ## [3.6.0] - 2026-05-01
 ### Changed
 - **SizeToken:** Expanded size type to include shorthand tokens `'xs' | 's' | 'm' | 'l' | 'xl'` alongside the existing `'small' | 'medium' | 'large'`, matching Web Awesome 3.6.0. This affects all components with a `size` property: `wa-button`, `wa-callout`, `wa-checkbox`, `wa-color-picker`, `wa-combobox`, `wa-dropdown`, `wa-file-input`, `wa-input`, `wa-number-input`, `wa-radio`, `wa-radio-group`, `wa-rating`, `wa-select`, `wa-slider`, `wa-switch`, `wa-tag`, `wa-textarea`, `wa-toast-item`.
@@ -234,3 +260,5 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 [3.4.0]: https://github.com/GedMarc/angular-awesome/compare/3.3.2...3.4.0
 [3.5.0]: https://github.com/GedMarc/angular-awesome/compare/3.4.0...3.5.0
 [3.5.1]: https://github.com/GedMarc/angular-awesome/compare/3.5.0...3.5.1
+[3.6.0]: https://github.com/GedMarc/angular-awesome/compare/3.5.1...3.6.0
+[3.7.0]: https://github.com/GedMarc/angular-awesome/compare/3.6.0...3.7.0

--- a/README.md
+++ b/README.md
@@ -16,17 +16,17 @@
 - **Template form error-state management** — wrappers participate in Angular validation so template-driven errors and state flags are available without extra plumbing.
 - **No custom schema required** — importing standalone wrappers avoids needing `CUSTOM_ELEMENTS_SCHEMA` just to use Web Awesome tags.
 - **Lazy loading where it matters** — selected components support lazy-loading patterns to reduce initial bundle and render cost.
-- **Full component coverage** — 70+ directives including layout primitives, form controls, navigation, overlays, charts, toasts, and more.
+- **Full component coverage** — 72+ directives including layout primitives, form controls, navigation, overlays, charts, media, toasts, and more.
 - **Type safety** — full TypeScript declarations with strict mode support.
 - **Lightweight** — thin wrappers with zero extra runtime dependencies beyond Angular and Web Awesome.
 
 ## Prerequisites
 
-| Dependency | Version |
-|------------|---------|
-| Angular    | `>=20.0` |
-| Node.js    | `20+`   |
-| Web Awesome | `3.5.x` |
+| Dependency   | Version  |
+|--------------|----------|
+| Angular      | `>=20.0` |
+| Node.js      | `20+`    |
+| Web Awesome* | `3.3.x`  |
 
 ## Installation
 
@@ -58,21 +58,21 @@ export class MyComponent {
 ## Available Components
 
 <details>
-<summary>Expand full component list (70+)</summary>
+<summary>Expand full component list (72+)</summary>
 
-| Category | Components |
-|----------|-----------|
-| **Layout** | `wa-layout-align`, `wa-layout-cluster`, `wa-layout-flank`, `wa-layout-frame`, `wa-layout-gap`, `wa-layout-grid`, `wa-layout-split`, `wa-layout-stack` |
-| **Navigation** | `wa-breadcrumbs`, `wa-tab-group`, `wa-tree` |
-| **Buttons** | `wa-button`, `wa-button-group`, `wa-copy-button` |
+| Category          | Components                                                                                                                                                                      |
+|-------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Layout**        | `wa-layout-align`, `wa-layout-cluster`, `wa-layout-flank`, `wa-layout-frame`, `wa-layout-gap`, `wa-layout-grid`, `wa-layout-split`, `wa-layout-stack`                           |
+| **Navigation**    | `wa-breadcrumbs`, `wa-tab-group`, `wa-tree`                                                                                                                                     |
+| **Buttons**       | `wa-button`, `wa-button-group`, `wa-copy-button`                                                                                                                                |
 | **Form Controls** | `wa-checkbox`, `wa-color-picker`, `wa-combobox`, `wa-file-input`, `wa-input`, `wa-number-input`, `wa-radio`, `wa-rating`, `wa-select`, `wa-slider`, `wa-switch`, `wa-text-area` |
-| **Data Display** | `wa-avatar`, `wa-badge`, `wa-card`, `wa-carousel`, `wa-comparison`, `wa-icon`, `wa-skeleton`, `wa-sparkline`, `wa-tag`, `wa-text`, `wa-qr-code` |
-| **Charts** | `wa-chart`, `wa-bar-chart`, `wa-bubble-chart`, `wa-doughnut-chart`, `wa-line-chart`, `wa-pie-chart`, `wa-polar-area-chart`, `wa-radar-chart`, `wa-scatter-chart` |
-| **Feedback** | `wa-callout`, `wa-dialog`, `wa-drawer`, `wa-popover`, `wa-popup`, `wa-toast`, `wa-toast-item`, `wa-tooltip` |
-| **Progress** | `wa-progress-bar`, `wa-progress-ring`, `wa-spinner` |
-| **Formatting** | `wa-format-bytes`, `wa-format-date`, `wa-format-number`, `wa-relative-time` |
-| **Media** | `wa-animated-image`, `wa-animation`, `wa-zoomable-frame` |
-| **Utilities** | `wa-divider`, `wa-dropdown`, `wa-include`, `wa-intersection-observer`, `wa-markdown`, `wa-mutation-observer`, `wa-resize-observer`, `wa-scroller`, `wa-split-panel` |
+| **Data Display**  | `wa-avatar`, `wa-badge`, `wa-card`, `wa-carousel`, `wa-comparison`, `wa-icon`, `wa-skeleton`, `wa-sparkline`, `wa-tag`, `wa-text`, `wa-qr-code`                                 |
+| **Charts**        | `wa-chart`, `wa-bar-chart`, `wa-bubble-chart`, `wa-doughnut-chart`, `wa-line-chart`, `wa-pie-chart`, `wa-polar-area-chart`, `wa-radar-chart`, `wa-scatter-chart`                |
+| **Feedback**      | `wa-callout`, `wa-dialog`, `wa-drawer`, `wa-popover`, `wa-popup`, `wa-toast`, `wa-toast-item`, `wa-tooltip`                                                                     |
+| **Progress**      | `wa-progress-bar`, `wa-progress-ring`, `wa-spinner`                                                                                                                             |
+| **Formatting**    | `wa-format-bytes`, `wa-format-date`, `wa-format-number`, `wa-relative-time`                                                                                                     |
+| **Media**         | `wa-animated-image`, `wa-animation`, `wa-video`, `wa-video-playlist`, `wa-zoomable-frame`                                                                                       |
+| **Utilities**     | `wa-divider`, `wa-dropdown`, `wa-include`, `wa-intersection-observer`, `wa-markdown`, `wa-mutation-observer`, `wa-resize-observer`, `wa-scroller`, `wa-split-panel`             |
 
 </details>
 
@@ -111,7 +111,7 @@ src/
 │   ├── button/
 │   ├── checkbox/
 │   ├── dialog/
-│   └── ...           # 70+ component directories
+│   └── ...           # 72+ component directories
 ├── services/         # Shared Angular services (e.g. toast service)
 ├── types/            # Shared TypeScript types
 ├── public-api.ts     # Library public API surface

--- a/docs/components.html
+++ b/docs/components.html
@@ -161,7 +161,7 @@
 </head>
 <body>
     <header>
-        <h1>Angular Awesome Components <span class="version-badge">synced with Web Awesome 3.2.x</span></h1>
+        <h1>Angular Awesome Components <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
         <p class="subtitle">Complete list of components and directives</p>
         <p>
             <a href="index.html">Home</a> |
@@ -194,7 +194,7 @@
         </div>
 
         <div class="component-list">
-            
+
             <div class="component-card" data-category="utility">
                 <h3>AnimatedImage <span class="tag">Utility</span></h3>
                 <p><wa-animated-image> provides animated image functionality for Angular applications.</p>
@@ -253,7 +253,8 @@
             </div>
             <div class="component-card" data-category="input">
                 <h3>Button <span class="tag">Input</span></h3>
-                <p><wa-button> is an interactive element that represents an action. It supports multiple variants, appearances, and sizes. It can also render as a link when href is provided.</p>
+                <p><wa-button> is an interactive element that represents an action. It supports multiple variants, appearances, and sizes. It can also render as a link when href is provided.
+</p>
                 <div class="links">
                     <a href="components/button.html">Documentation</a>
                     <a href="https://github.com/GedMarc/angular-awesome/tree/master/src/directives/button" target="_blank">Source</a>
@@ -261,7 +262,8 @@
             </div>
             <div class="component-card" data-category="utility">
                 <h3>Callout <span class="tag">Utility</span></h3>
-                <p><wa-callout> displays inline messages or alerts. It supports color variants, size and appearance options, and an optional icon via slot.</p>
+                <p><wa-callout> displays inline messages or alerts. It supports color variants, size and appearance options, and an optional icon via slot.
+</p>
                 <div class="links">
                     <a href="components/callout.html">Documentation</a>
                     <a href="https://github.com/GedMarc/angular-awesome/tree/master/src/directives/callout" target="_blank">Source</a>
@@ -501,7 +503,8 @@
             </div>
             <div class="component-card" data-category="input">
                 <h3>Option <span class="tag">Input</span></h3>
-                <p>Angular directive support for the wa-option Web Component. Options define the selectable items within various form controls such as <wa-select> and <wa-combobox>.</p>
+                <p>Angular directive support for the wa-option Web Component. Options define the selectable items within various form controls such as <wa-select> and <wa-combobox>.
+</p>
                 <div class="links">
                     <a href="components/option.html">Documentation</a>
                     <a href="https://github.com/GedMarc/angular-awesome/tree/master/src/directives/option" target="_blank">Source</a>
@@ -509,7 +512,8 @@
             </div>
             <div class="component-card" data-category="layout">
                 <h3>Page <span class="tag">Layout</span></h3>
-                <p>The <wa-page> component is a comprehensive layout container that structures web pages with rich support for slots and responsive navigation. The Angular wrapper must support full slot projection, input bindings for layout control, and imperative methods for toggling the navigation drawer.</p>
+                <p>The <wa-page> component is a comprehensive layout container that structures web pages with rich support for slots and responsive navigation. The Angular wrapper must support full slot projection, input bindings for layout control, and imperative methods for toggling the navigation drawer.
+</p>
                 <div class="links">
                     <a href="components/page.html">Documentation</a>
                     <a href="https://github.com/GedMarc/angular-awesome/tree/master/src/directives/page" target="_blank">Source</a>
@@ -597,7 +601,8 @@
             </div>
             <div class="component-card" data-category="utility">
                 <h3>RelativeTime <span class="tag">Utility</span></h3>
-                <p>The wa-relative-time component displays a localized phrase indicating the relative time from a given date to now. It supports automatic updates, multiple formatting styles, and localization.</p>
+                <p>The wa-relative-time component displays a localized phrase indicating the relative time from a given date to now. It supports automatic updates, multiple formatting styles, and localization.
+</p>
                 <div class="links">
                     <a href="components/relative-time.html">Documentation</a>
                     <a href="https://github.com/GedMarc/angular-awesome/tree/master/src/directives/relative-time" target="_blank">Source</a>
@@ -605,7 +610,8 @@
             </div>
             <div class="component-card" data-category="utility">
                 <h3>ResizeObserver <span class="tag">Utility</span></h3>
-                <p>Angular directive support for the wa-resize-observer Web Component. The Resize Observer component offers a thin, declarative interface to the ResizeObserver API.</p>
+                <p>Angular directive support for the wa-resize-observer Web Component. The Resize Observer component offers a thin, declarative interface to the ResizeObserver API.
+</p>
                 <div class="links">
                     <a href="components/resize-observer.html">Documentation</a>
                     <a href="https://github.com/GedMarc/angular-awesome/tree/master/src/directives/resize-observer" target="_blank">Source</a>
@@ -653,7 +659,8 @@
             </div>
             <div class="component-card" data-category="feedback">
                 <h3>Spinner <span class="tag">Feedback</span></h3>
-                <p>This Angular wrapper corresponds to the <wa-spinner> Web Awesome component.</p>
+                <p>This Angular wrapper corresponds to the <wa-spinner> Web Awesome component.
+</p>
                 <div class="links">
                     <a href="components/spinner.html">Documentation</a>
                     <a href="https://github.com/GedMarc/angular-awesome/tree/master/src/directives/spinner" target="_blank">Source</a>
@@ -701,7 +708,8 @@
             </div>
             <div class="component-card" data-category="feedback">
                 <h3>Toast <span class="tag">Feedback</span></h3>
-                <p>Toasts are small, contextual notifications that appear on the screen and disappear automatically or can be dismissed by the user. This implementation uses the official Web Awesome toast components and supports:</p>
+                <p>Toasts are small, contextual notifications that appear on the screen and disappear automatically or can be dismissed by the user. This implementation uses the official Web Awesome toast components and supports:
+</p>
                 <div class="links">
                     <a href="components/toast.html">Documentation</a>
                     <a href="https://github.com/GedMarc/angular-awesome/tree/master/src/directives/toast" target="_blank">Source</a>
@@ -725,10 +733,27 @@
             </div>
             <div class="component-card" data-category="utility">
                 <h3>Variant <span class="tag">Utility</span></h3>
-                <p>- Purpose: make it easy to toggle color variants on arbitrary elements, mirroring component variant behavior.</p>
+                <p>- Purpose: make it easy to toggle color variants on arbitrary elements, mirroring component variant behavior.
+</p>
                 <div class="links">
                     <a href="components/variant.html">Documentation</a>
                     <a href="https://github.com/GedMarc/angular-awesome/tree/master/src/directives/variant" target="_blank">Source</a>
+                </div>
+            </div>
+            <div class="component-card" data-category="utility">
+                <h3>Video <span class="tag">Utility</span></h3>
+                <p>&lt;wa-video&gt; embeds and plays video content with custom controls, captions, and full programmatic playback control including play/pause, seek, volume, playback rate, and fullscreen.</p>
+                <div class="links">
+                    <a href="components/video.html">Documentation</a>
+                    <a href="https://github.com/GedMarc/angular-awesome/tree/master/src/directives/video" target="_blank">Source</a>
+                </div>
+            </div>
+            <div class="component-card" data-category="utility">
+                <h3>VideoPlaylist <span class="tag">Utility</span></h3>
+                <p>&lt;wa-video-playlist&gt; wraps multiple &lt;wa-video&gt; elements into a playlist with a navigation sidebar, next/previous controls, and a wa-video-change event when the active video changes.</p>
+                <div class="links">
+                    <a href="components/video.html">Documentation</a>
+                    <a href="https://github.com/GedMarc/angular-awesome/tree/master/src/directives/video" target="_blank">Source</a>
                 </div>
             </div>
         </div>

--- a/docs/components/animated-image.html
+++ b/docs/components/animated-image.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>AnimatedImage Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>AnimatedImage Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-animated-image> provides animated image functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/animation.html
+++ b/docs/components/animation.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Animation Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Animation Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-animation> provides animation functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/avatar.html
+++ b/docs/components/avatar.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Avatar Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Avatar Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-avatar> provides avatar functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/badge.html
+++ b/docs/components/badge.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Badge Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Badge Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-badge> provides badge functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/bar-chart.html
+++ b/docs/components/bar-chart.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>BarChart Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>BarChart Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-bar-chart> provides bar chart functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/breadcrumbs.html
+++ b/docs/components/breadcrumbs.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Breadcrumbs Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Breadcrumbs Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-breadcrumbs> provides breadcrumbs functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/bubble-chart.html
+++ b/docs/components/bubble-chart.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>BubbleChart Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>BubbleChart Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-bubble-chart> provides bubble chart functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/button-group.html
+++ b/docs/components/button-group.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>ButtonGroup Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>ButtonGroup Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-button-group> provides button group functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/button.html
+++ b/docs/components/button.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Button Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Button Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-button> is an interactive element that represents an action. It supports multiple variants, appearances, and sizes. It can also render as a link when href is provided.</p>
             </header>
 

--- a/docs/components/callout.html
+++ b/docs/components/callout.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Callout Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Callout Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-callout> displays inline messages or alerts. It supports color variants, size and appearance options, and an optional icon via slot.</p>
             </header>
 

--- a/docs/components/card.html
+++ b/docs/components/card.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Card Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Card Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-card> provides card functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/carousel.html
+++ b/docs/components/carousel.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Carousel Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Carousel Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-carousel> provides carousel functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/chart.html
+++ b/docs/components/chart.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Chart Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Chart Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-chart> provides chart functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/checkbox.html
+++ b/docs/components/checkbox.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Checkbox Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Checkbox Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-checkbox> provides checkbox functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/color-picker.html
+++ b/docs/components/color-picker.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>ColorPicker Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>ColorPicker Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-color-picker> provides color picker functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/combobox.html
+++ b/docs/components/combobox.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Combobox Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Combobox Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-combobox> provides combobox functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/comparison.html
+++ b/docs/components/comparison.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Comparison Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Comparison Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-comparison> provides comparison functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/copy-button.html
+++ b/docs/components/copy-button.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>CopyButton Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>CopyButton Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-copy-button> provides copy button functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/details.html
+++ b/docs/components/details.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Details Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Details Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-details> provides details functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/dialog.html
+++ b/docs/components/dialog.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Dialog Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Dialog Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-dialog> provides dialog functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/divider.html
+++ b/docs/components/divider.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Divider Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Divider Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-divider> provides divider functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/doughnut-chart.html
+++ b/docs/components/doughnut-chart.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>DoughnutChart Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>DoughnutChart Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-doughnut-chart> provides doughnut chart functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/drawer.html
+++ b/docs/components/drawer.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Drawer Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Drawer Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-drawer> provides drawer functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/dropdown.html
+++ b/docs/components/dropdown.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Dropdown Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Dropdown Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-dropdown> provides dropdown functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/file-input.html
+++ b/docs/components/file-input.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>FileInput Component <span class="version-badge">synced with Web Awesome 3.3.x</span></h1>
+                <h1>FileInput Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-file-input> lets users select files via click or drag-and-drop. It supports single or multiple selection, accept filters, and SSR-friendly label/hint rendering.</p>
             </header>
 

--- a/docs/components/format-bytes.html
+++ b/docs/components/format-bytes.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>FormatBytes Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>FormatBytes Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-format-bytes> provides format bytes functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/format-date.html
+++ b/docs/components/format-date.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>FormatDate Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>FormatDate Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-format-date> provides format date functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/format-number.html
+++ b/docs/components/format-number.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>FormatNumber Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>FormatNumber Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-format-number> provides format number functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/icon.html
+++ b/docs/components/icon.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Icon Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Icon Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-icon> provides icon functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/include.html
+++ b/docs/components/include.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Include Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Include Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-include> provides include functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/input.html
+++ b/docs/components/input.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Input Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Input Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-input> provides input functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/intersection-observer.html
+++ b/docs/components/intersection-observer.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>IntersectionObserver Component <span class="version-badge">synced with Web Awesome 3.3.x</span></h1>
+                <h1>IntersectionObserver Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-intersection-observer> provides intersection observer functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/layout-align.html
+++ b/docs/components/layout-align.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>LayoutAlign Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>LayoutAlign Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-layout-align> provides layout align functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/layout-cluster.html
+++ b/docs/components/layout-cluster.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>LayoutCluster Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>LayoutCluster Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-layout-cluster> provides layout cluster functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/layout-flank.html
+++ b/docs/components/layout-flank.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>LayoutFlank Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>LayoutFlank Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-layout-flank> provides layout flank functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/layout-frame.html
+++ b/docs/components/layout-frame.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>LayoutFrame Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>LayoutFrame Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-layout-frame> provides layout frame functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/layout-gap.html
+++ b/docs/components/layout-gap.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>LayoutGap Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>LayoutGap Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-layout-gap> provides layout gap functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/layout-grid.html
+++ b/docs/components/layout-grid.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>LayoutGrid Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>LayoutGrid Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-layout-grid> provides layout grid functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/layout-split.html
+++ b/docs/components/layout-split.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>LayoutSplit Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>LayoutSplit Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-layout-split> provides layout split functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/layout-stack.html
+++ b/docs/components/layout-stack.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>LayoutStack Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>LayoutStack Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-layout-stack> provides layout stack functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/line-chart.html
+++ b/docs/components/line-chart.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>LineChart Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>LineChart Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-line-chart> provides line chart functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/mutation-observer.html
+++ b/docs/components/mutation-observer.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>MutationObserver Component <span class="version-badge">synced with Web Awesome 3.3.x</span></h1>
+                <h1>MutationObserver Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-mutation-observer> provides mutation observer functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/number-input.html
+++ b/docs/components/number-input.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>NumberInput Component <span class="version-badge">synced with Web Awesome 3.3.x</span></h1>
+                <h1>NumberInput Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-number-input> is a numeric form control with optional steppers and rich configuration. It is form-associated and works with native validation.</p>
             </header>
 

--- a/docs/components/option.html
+++ b/docs/components/option.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Option Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Option Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle">Angular directive support for the wa-option Web Component. Options define the selectable items within various form controls such as <wa-select> and <wa-combobox>.</p>
             </header>
 

--- a/docs/components/page.html
+++ b/docs/components/page.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Page Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Page Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle">The <wa-page> component is a comprehensive layout container that structures web pages with rich support for slots and responsive navigation. The Angular wrapper must support full slot projection, input bindings for layout control, and imperative methods for toggling the navigation drawer.</p>
             </header>
 

--- a/docs/components/pie-chart.html
+++ b/docs/components/pie-chart.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>PieChart Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>PieChart Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-pie-chart> provides pie chart functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/polar-area-chart.html
+++ b/docs/components/polar-area-chart.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>PolarAreaChart Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>PolarAreaChart Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-polar-area-chart> provides polar area chart functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/popover.html
+++ b/docs/components/popover.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Popover Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Popover Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-popover> provides popover functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/popup.html
+++ b/docs/components/popup.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Popup Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Popup Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-popup> provides popup functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/progress-bar.html
+++ b/docs/components/progress-bar.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>ProgressBar Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>ProgressBar Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-progress-bar> provides progress bar functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/progress-ring.html
+++ b/docs/components/progress-ring.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>ProgressRing Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>ProgressRing Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-progress-ring> provides progress ring functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/qr-code.html
+++ b/docs/components/qr-code.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>QrCode Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>QrCode Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-qr-code> provides qr code functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/radar-chart.html
+++ b/docs/components/radar-chart.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>RadarChart Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>RadarChart Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-radar-chart> provides radar chart functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/radio.html
+++ b/docs/components/radio.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Radio Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Radio Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-radio> provides radio functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/rating.html
+++ b/docs/components/rating.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Rating Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Rating Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-rating> provides rating functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/relative-time.html
+++ b/docs/components/relative-time.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>RelativeTime Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>RelativeTime Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle">The wa-relative-time component displays a localized phrase indicating the relative time from a given date to now. It supports automatic updates, multiple formatting styles, and localization.</p>
             </header>
 

--- a/docs/components/resize-observer.html
+++ b/docs/components/resize-observer.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>ResizeObserver Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>ResizeObserver Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle">Angular directive support for the wa-resize-observer Web Component. The Resize Observer component offers a thin, declarative interface to the ResizeObserver API.</p>
             </header>
 

--- a/docs/components/scatter-chart.html
+++ b/docs/components/scatter-chart.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>ScatterChart Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>ScatterChart Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-scatter-chart> provides scatter chart functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/scroller.html
+++ b/docs/components/scroller.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Scroller Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Scroller Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-scroller> provides scroller functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/select.html
+++ b/docs/components/select.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Select Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Select Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-select> provides select functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/skeleton.html
+++ b/docs/components/skeleton.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Skeleton Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Skeleton Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-skeleton> provides skeleton functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/slider.html
+++ b/docs/components/slider.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Slider Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Slider Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-slider> is an range input component that supports single and dual-thumb range selection, vertical orientation, markers, tooltips, reference labels, and custom styling.</p>
             </header>
 

--- a/docs/components/sparkline.html
+++ b/docs/components/sparkline.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Sparkline Component <span class="version-badge">synced with Web Awesome 3.3.x</span></h1>
+                <h1>Sparkline Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-sparkline> renders compact, inline data trends. Choose an appearance (solid, line, gradient), optionally indicate a trend, and select a curve.</p>
             </header>
 

--- a/docs/components/spinner.html
+++ b/docs/components/spinner.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Spinner Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Spinner Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle">This Angular wrapper corresponds to the <wa-spinner> Web Awesome component.</p>
             </header>
 

--- a/docs/components/split-panel.html
+++ b/docs/components/split-panel.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>SplitPanel Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>SplitPanel Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-split-panel> provides split panel functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/switch.html
+++ b/docs/components/switch.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Switch Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Switch Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-switch> provides switch functionality for Angular applications.</p>
             </header>
 
@@ -103,7 +103,7 @@
         <h2>Import</h2>
         <p>Import the switch directive from the angular-awesome package:</p>
         <pre>// Import the switch directive
-import {Directive } from 'angular-awesome/switch';</pre>
+import { WaSwitchDirective } from 'angular-awesome/switch';</pre>
       </section>
 
       <section>
@@ -143,7 +143,6 @@ import {Directive } from 'angular-awesome/switch';</pre>
 
 &lt;!-- Combined custom styling --&gt;
 &lt;wa-switch 
-  
   [backgroundColor]=&quot;&#39;#f0f0f0&#39;&quot; 
   [backgroundColorChecked]=&quot;&#39;#673AB7&#39;&quot; 
   [borderColor]=&quot;&#39;#ccc&#39;&quot; 
@@ -161,7 +160,7 @@ import {Directive } from 'angular-awesome/switch';</pre>
 <h2>Using with Angular Forms</h2>
 <pre><code class="language-typescript">import { Component } from &#39;@angular/core&#39;;
 import { FormsModule } from &#39;@angular/forms&#39;;
-import {Directive } from &#39;@angular-awesome/directives/switch&#39;;
+import { WaSwitchDirective } from &#39;@angular-awesome/directives/switch&#39;;
 
 @Component({
   selector: &#39;app-switch-demo&#39;,
@@ -186,13 +185,12 @@ export class SwitchDemoComponent {
 </code></pre>
 <h2>Event Handling</h2>
 <pre><code class="language-typescript">import { Component } from &#39;@angular/core&#39;;
-import {Directive } from &#39;@angular-awesome/directives/switch&#39;;
+import { WaSwitchDirective } from &#39;@angular-awesome/directives/switch&#39;;
 
 @Component({
   selector: &#39;app-switch-events-demo&#39;,
   template: `
     &lt;wa-switch 
-      
       [hint]=&quot;&#39;Notifications&#39;&quot;
       (changeEvent)=&quot;onSwitchChange($event)&quot;
       (inputEvent)=&quot;onSwitchInput($event)&quot;
@@ -236,7 +234,7 @@ export class SwitchEventsDemoComponent {
 <h2>Reactive Forms</h2>
 <pre><code class="language-typescript">import { Component, OnInit } from &#39;@angular/core&#39;;
 import { FormBuilder, FormGroup, ReactiveFormsModule } from &#39;@angular/forms&#39;;
-import {Directive } from &#39;@angular-awesome/directives/switch&#39;;
+import { WaSwitchDirective } from &#39;@angular-awesome/directives/switch&#39;;
 
 @Component({
   selector: &#39;app-switch-reactive-form-demo&#39;,

--- a/docs/components/tab-group.html
+++ b/docs/components/tab-group.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>TabGroup Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>TabGroup Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-tab-group> provides tab group functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/tag.html
+++ b/docs/components/tag.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Tag Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Tag Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-tag> provides tag functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/text-area.html
+++ b/docs/components/text-area.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>TextArea Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>TextArea Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-text-area> provides text area functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/text.html
+++ b/docs/components/text.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Text Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Text Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-text> provides text functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/toast.html
+++ b/docs/components/toast.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Toast Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Toast Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle">Toasts are small, contextual notifications that appear on the screen and disappear automatically or can be dismissed by the user. This implementation uses the official Web Awesome toast components and supports:</p>
             </header>
 

--- a/docs/components/tooltip.html
+++ b/docs/components/tooltip.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Tooltip Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Tooltip Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-tooltip> provides tooltip functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/tooltitp.html
+++ b/docs/components/tooltitp.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Tooltitp Component <span class="version-badge">synced with Web Awesome 3.0.0</span></h1>
+                <h1>Tooltitp Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-tooltitp> provides tooltitp functionality for Angular applications.</p>
                 <p style="margin-top:6px;color:#666;font-size:0.9rem;">Preparing for Web Awesome 1.0.0. This wrapper will not target a version above 1.0.0 until it is released.</p>
             </header>

--- a/docs/components/tree.html
+++ b/docs/components/tree.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Tree Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Tree Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-tree> provides tree functionality for Angular applications.</p>
             </header>
 

--- a/docs/components/variant.html
+++ b/docs/components/variant.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>Variant Component <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>Variant Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle">- Purpose: make it easy to toggle color variants on arbitrary elements, mirroring component variant behavior.</p>
             </header>
 

--- a/docs/components/zoomable-frame.html
+++ b/docs/components/zoomable-frame.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>ZoomableFrame Component <span class="version-badge">synced with Web Awesome 3.3.x</span></h1>
+                <h1>ZoomableFrame Component <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle"><wa-zoomable-frame> provides zoomable frame functionality for Angular applications.</p>
             </header>
 

--- a/docs/includes/components-list-template.html
+++ b/docs/includes/components-list-template.html
@@ -161,7 +161,7 @@
 </head>
 <body>
     <header>
-        <h1>Angular Awesome Components <span class="version-badge">synced with Web Awesome 3.2.x</span></h1>
+        <h1>Angular Awesome Components <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
         <p class="subtitle">Complete list of components and directives</p>
         <p>
             <a href="index.html">Home</a> |

--- a/docs/includes/template.html
+++ b/docs/includes/template.html
@@ -87,7 +87,7 @@
         <!-- Main Content -->
         <div class="main-content">
             <header>
-                <h1>PAGE_TITLE <span class="version-badge">synced with Web Awesome 3.4.x</span></h1>
+                <h1>PAGE_TITLE <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
                 <p class="subtitle">PAGE_SUBTITLE</p>
             </header>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -154,7 +154,7 @@
 </head>
 <body>
     <header>
-        <h1>Angular Awesome <span class="version-badge">synced with Web Awesome 3.5.0</span></h1>
+        <h1>Angular Awesome <span class="version-badge">synced with Web Awesome 3.7.0</span></h1>
         <p class="subtitle">Angular 20+ wrapper for the Web Awesome UI framework</p>
         <p>
             <a href="https://github.com/GedMarc/angular-awesome" target="_blank">GitHub Repository</a> |

--- a/llms_3.7.0.txt
+++ b/llms_3.7.0.txt
@@ -1,0 +1,3449 @@
+# Web Awesome
+
+> A forward-thinking library of web components. Version 3.7.0.
+
+Web Awesome provides a comprehensive set of customizable, accessible web components for building modern
+web applications. All components use shadow DOM and are framework-agnostic, working with vanilla JavaScript
+or any framework including React, Vue, Angular, and Svelte.
+
+Form controls are form-associated custom elements that work with native form validation and the
+Constraint Validation API.
+
+Font Awesome is the default icon library, so `<wa-icon name="...">` values should reference Font Awesome
+icon names.
+
+## Documentation
+
+For comprehensive documentation, visit https://webawesome.com/docs/
+
+- [Getting Started](https://webawesome.com/docs/getting-started): Installation and setup guide
+- [Components Overview](https://webawesome.com/docs/components): Complete component reference
+- [Theming](https://webawesome.com/docs/theming): Customization and design tokens
+- [Form Controls](https://webawesome.com/docs/form-controls): Form integration and validation
+
+## Components
+
+- [Animated Image](https://webawesome.com/docs/components/animated-image): Animated images display GIFs and WEBPs with controls to play and pause them on demand. Use them when you want motion but need to give users control over when it plays.
+- [Animation](https://webawesome.com/docs/components/animation): Animate elements declaratively with nearly 100 baked-in presets, or roll your own with custom keyframes. Powered by the Web Animations API.
+- [Avatar](https://webawesome.com/docs/components/avatar): Avatars represent a person or object with an image, initials, or icon. Use them in lists, comments, and profiles to give users visual context at a glance.
+- [Badge](https://webawesome.com/docs/components/badge): Badges draw attention to adjacent content by displaying a status, count, or label. Use them to highlight notifications, categorize items, or flag new activity.
+- [Bar Chart](https://webawesome.com/docs/components/bar-chart): Bar charts compare quantities across categories using rectangular bars. They work well for showing rankings, highlighting differences between groups, and tracking changes across time periods.
+- [Breadcrumb](https://webawesome.com/docs/components/breadcrumb): Breadcrumbs display a trail of links that show users where they are in a site's hierarchy. They help users understand the current location and navigate back to parent pages.
+- [Breadcrumb Item](https://webawesome.com/docs/components/breadcrumb-item): Breadcrumb items represent individual links inside a breadcrumb, typically one per level of the site hierarchy.
+- [Bubble Chart](https://webawesome.com/docs/components/bubble-chart): Bubble charts add a third dimension to scatter plots by varying the size of each data point. They are useful for visualizing relationships where a third variable adds meaning beyond a simple x/y correlation.
+- [Button](https://webawesome.com/docs/components/button): Buttons represent actions the user can take, such as submitting a form, opening a dialog, or navigating to another page.
+- [Button Group](https://webawesome.com/docs/components/button-group): Button groups combine related buttons into a single visual unit. Use them for toolbars, segmented controls, or any set of actions that belong together.
+- [Callout](https://webawesome.com/docs/components/callout): Callouts display important messages inline with surrounding content. Use them to highlight tips, warnings, errors, or other information users should not miss.
+- [Card](https://webawesome.com/docs/components/card): Cards group related content and actions inside a bordered container. Use them to present products, articles, user profiles, or any self-contained unit of information.
+- [Carousel](https://webawesome.com/docs/components/carousel): Carousels display a series of content slides along a horizontal or vertical axis, one or more at a time. Users can navigate between slides with controls, pagination, or autoplay.
+- [Carousel Item](https://webawesome.com/docs/components/carousel-item): Carousel items represent individual slides within a carousel.
+- [Chart](https://webawesome.com/docs/components/chart): Charts provide a flexible wrapper around Chart.js for building themed data visualizations. Use this component for advanced configuration such as mixed chart types, custom plugins, and direct Chart.js instance access.
+- [Checkbox](https://webawesome.com/docs/components/checkbox): Checkboxes let users toggle an option on or off, or select multiple items from a list. They also support an indeterminate state for partial selections in groups.
+- [Color Picker](https://webawesome.com/docs/components/color-picker): Color pickers let users choose a color from a visual palette or by entering a value. They support HEX, RGB, HSL, and HSV formats with optional alpha channel and swatch presets.
+- [Combobox](https://webawesome.com/docs/components/combobox): Comboboxes combine a text input with a listbox, allowing users to filter and select from predefined options or enter custom values.
+- [Comparison](https://webawesome.com/docs/components/comparison): Comparisons show the visual differences between two pieces of similar content using a draggable divider. Use them for before/after images, design revisions, or side-by-side previews.
+- [Copy Button](https://webawesome.com/docs/components/copy-button): Copy buttons copy text to the clipboard when the user activates them. They provide built-in success and error feedback so users know the copy worked.
+- [Details](https://webawesome.com/docs/components/details): Details display a brief summary and expand to reveal additional content. Use them to progressively disclose information, group related FAQs, or hide advanced options.
+- [Dialog](https://webawesome.com/docs/components/dialog): Dialogs appear above the page and require the user's immediate attention. Use them for confirmations, forms, or focused tasks that interrupt the main flow.
+- [Divider](https://webawesome.com/docs/components/divider): Dividers visually separate or group adjacent elements with a horizontal or vertical line. Use them to establish rhythm and hierarchy within menus, toolbars, and layouts.
+- [Doughnut Chart](https://webawesome.com/docs/components/doughnut-chart): Doughnut charts show proportional data as slices of a ring with a hollow center. They offer a cleaner look than pie charts and work well in dashboards where the center space can provide additional context.
+- [Drawer](https://webawesome.com/docs/components/drawer): Drawers slide in from the edge of a container to expose additional options and information without navigating away. Useful for navigation menus, filters, and secondary content.
+- [Dropdown](https://webawesome.com/docs/components/dropdown): Dropdowns display a list of options triggered by a button or other element. They support keyboard navigation, submenus, and checkable items for building menus and context actions.
+- [Dropdown Item](https://webawesome.com/docs/components/dropdown-item): Dropdown items represent selectable entries within a dropdown menu, including standard actions, checkable items, and submenu triggers.
+- [File Input](https://webawesome.com/docs/components/file-input): File inputs allow users to select files from their device.
+- [Format Bytes](https://webawesome.com/docs/components/format-bytes): Formats a number of bytes as a human-readable string with the appropriate unit, such as kB, MB, or GB. Supports both byte and bit units with configurable locale.
+- [Format Date](https://webawesome.com/docs/components/format-date): Formats a date or time for display using the specified locale and options. Powered by the Intl.DateTimeFormat API for consistent, localized output.
+- [Format Number](https://webawesome.com/docs/components/format-number): Formats a number for display using the specified locale and options, including currency, percent, and unit styles. Powered by the Intl.NumberFormat API.
+- [Icon](https://webawesome.com/docs/components/icon): Icons are scalable vector symbols that represent actions, content, or status throughout your application. They support Font Awesome and custom icon libraries with animation presets.
+- [Include](https://webawesome.com/docs/components/include): Fetches an external HTML file and embeds its contents inline on the page. Useful for reusing shared markup like headers, footers, and partials across multiple pages.
+- [Input](https://webawesome.com/docs/components/input): Inputs collect single-line data from the user, such as text, numbers, email addresses, and passwords. They support labels, hints, validation, and prefix or suffix slots.
+- [Intersection Observer](https://webawesome.com/docs/components/intersection-observer): Tracks immediate child elements and fires events as they move in and out of view. Useful for lazy loading, scroll-triggered animations, and viewport-aware interactions.
+- [Line Chart](https://webawesome.com/docs/components/line-chart): Line charts show trends over time by connecting data points with line segments. Use them when the x-axis represents a sequential dimension and you want to emphasize the shape and direction of the data.
+- [Markdown](https://webawesome.com/docs/components/markdown): Markdown elements render markdown content as HTML directly in the browser, making it easy to display user-generated content or documentation without a server-side build step.
+- [Mutation Observer](https://webawesome.com/docs/components/mutation-observer): Mutation observers watch for changes to an element's DOM tree and emit an event when they occur. Provides a thin, declarative interface to the browser's MutationObserver API.
+- [Number Input](https://webawesome.com/docs/components/number-input): Number inputs let users enter and edit numeric values, with optional stepper buttons for incrementing and decrementing. Use them for quantities, measurements, and other numeric form fields.
+- [Option](https://webawesome.com/docs/components/option): Options represent the individual choices inside a select or similar form control. Each option holds a value and the label shown to the user.
+- [Page](https://webawesome.com/docs/components/page): Pages scaffold an entire application layout with header, navigation, sidebar, main content, aside, and footer regions. Use them to structure full pages with minimal markup and responsive behavior built in.
+- [Pie Chart](https://webawesome.com/docs/components/pie-chart): Pie charts show the proportional composition of a whole as slices of a circle. They work best with a small number of categories where the relative proportions matter more than exact values.
+- [Polar Area Chart](https://webawesome.com/docs/components/polar-area-chart): Polar area charts compare values using segments that radiate from a center point with varying radius. Unlike pie charts, each segment has an equal angle while the radius varies, making them useful for comparing magnitudes without visual bias.
+- [Popover](https://webawesome.com/docs/components/popover): Popovers display contextual content and interactive elements in a floating panel anchored to a trigger. Use them for rich tooltips, menus, or any content that appears on demand without navigating away.
+- [Popup](https://webawesome.com/docs/components/popup): Popups declaratively anchor one element to another and keep them positioned together as the page scrolls or resizes. Primarily a low-level building block for popovers, dropdowns, and tooltips.
+- [Progress Bar](https://webawesome.com/docs/components/progress-bar): Progress bars show how far along an ongoing operation is as a horizontal fill. Use them for file uploads, multi-step flows, or any task with measurable progress.
+- [Progress Ring](https://webawesome.com/docs/components/progress-ring): Progress rings show how far along a determinate operation is using a circular indicator. Use them as a compact alternative to progress bars when horizontal space is limited.
+- [QR Code](https://webawesome.com/docs/components/qr-code): QR codes encode a URL or other short text into a scannable image, rendered client-side using the Canvas API. Use them to share links, contact info, or Wi-Fi credentials that visitors can scan with a phone.
+- [Radar Chart](https://webawesome.com/docs/components/radar-chart): Radar charts compare multiple variables at once by plotting data on a radial grid. They are well-suited for comparing profiles across several dimensions, such as skill assessments, product attributes, or performance metrics.
+- [Radio](https://webawesome.com/docs/components/radio): Radios represent a single option within a mutually exclusive set. Use them inside a radio group when users must pick exactly one choice from a small list.
+- [Radio Group](https://webawesome.com/docs/components/radio-group): Radio groups wrap a set of radios so they function as a single form control with one shared value. They handle keyboard navigation, labeling, and validation for the group as a whole.
+- [Rating](https://webawesome.com/docs/components/rating): Ratings display a numeric score as a row of selectable symbols, typically stars. Use them to capture quick feedback or show an average rating for a product or piece of content.
+- [Relative Time](https://webawesome.com/docs/components/relative-time): Relative times display a date as a localized phrase relative to now, such as "3 hours ago" or "in 2 days". The phrase updates automatically as time passes and respects the user's locale.
+- [Resize Observer](https://webawesome.com/docs/components/resize-observer): Resize observers watch their slotted elements for size changes and emit an event when they occur. Provides a thin, declarative interface to the browser's ResizeObserver API.
+- [Scatter Chart](https://webawesome.com/docs/components/scatter-chart): Scatter charts reveal relationships between two variables by plotting data points on a grid. They are ideal for identifying correlations, clusters, and outliers in datasets.
+- [Scroller](https://webawesome.com/docs/components/scroller): Scrollers wrap overflowing content in an accessible container with visual cues that help users recognize and navigate scrollable regions.
+- [Select](https://webawesome.com/docs/components/select): Selects let users choose one or more values from a dropdown list of predefined options. Use them in forms when a fixed set of choices needs to fit in limited space.
+- [Skeleton](https://webawesome.com/docs/components/skeleton): Skeletons show placeholder shapes where content will appear once it finishes loading, reducing perceived wait time and preventing layout shift.
+- [Slider](https://webawesome.com/docs/components/slider): Sliders let users choose a numeric value within a defined range by dragging a thumb along a track.
+- [Sparkline](https://webawesome.com/docs/components/sparkline): Sparklines display inline data trends as compact, visual charts.
+- [Spinner](https://webawesome.com/docs/components/spinner): Spinners indicate that an operation is in progress when the duration is unknown. Use them for loading states where a determinate progress bar isn't practical.
+- [Split Panel](https://webawesome.com/docs/components/split-panel): Split panels display two adjacent panels separated by a draggable divider, letting users resize each side to suit their workflow.
+- [Switch](https://webawesome.com/docs/components/switch): Switches toggle a single setting on or off and apply the change immediately, without requiring a form submission.
+- [Tab](https://webawesome.com/docs/components/tab): Tabs label and activate an individual panel inside a tab group.
+- [Tab Group](https://webawesome.com/docs/components/tab-group): Tab groups organize related content into a single container that displays one panel at a time, with tabs for switching between them.
+- [Tab Panel](https://webawesome.com/docs/components/tab-panel): Tab panels hold the content shown for a single tab inside a tab group.
+- [Tag](https://webawesome.com/docs/components/tag): Tags label, categorize, or represent selections with a compact visual marker. Use them for status indicators, filters, or removable chips.
+- [Textarea](https://webawesome.com/docs/components/textarea): Textareas collect multi-line text input from the user, with optional resizing and character counting.
+- [Toast](https://webawesome.com/docs/components/toast): Toasts display brief, non-blocking notifications that appear temporarily above the page content.
+- [Toast Item](https://webawesome.com/docs/components/toast-item): Toast items are individual notifications displayed within a toast container.
+- [Tooltip](https://webawesome.com/docs/components/tooltip): Tooltips display brief contextual information when the user hovers, focuses, or taps a target element.
+- [Tree](https://webawesome.com/docs/components/tree): Trees allow you to display a hierarchical list of selectable tree items. Items with children can be expanded and collapsed as desired by the user.
+- [Tree Item](https://webawesome.com/docs/components/tree-item): Tree items represent a single hierarchical node inside a tree, and can contain nested items that expand and collapse.
+- [Video](https://webawesome.com/docs/components/video): Videos are used to embed and play video content with custom controls, and captions.
+- [Video Playlist](https://webawesome.com/docs/components/video-playlist): Video playlist wraps multiple videos into a playlist with navigation controls and a sidebar.
+- [Zoomable Frame](https://webawesome.com/docs/components/zoomable-frame): Zoomable frames embed iframe content with built-in controls for zooming, panning, and managing interaction.
+
+## Optional
+
+The following is a quick reference describing every component's API. For comprehensive documentation, refer to the component documentation using the URLs provided above.
+
+#### `<wa-animated-image>`
+
+**Description:** Animated images display GIFs and WEBPs with controls to play and pause them on demand. Use them when you want motion but need to give users control over when it plays.
+
+**Documentation:** https://webawesome.com/docs/components/animated-image
+
+**Slots:**
+
+- `play-icon`: Optional play icon to use instead of the default. Works best with `<wa-icon>`.
+- `pause-icon`: Optional pause icon to use instead of the default. Works best with `<wa-icon>`.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `src`: The path to the image to load. (Type: `string`)
+- `alt`: A description of the image used by assistive devices. (Type: `string`)
+- `play`: Plays the animation. When this attribute is remove, the animation will pause. (Type: `boolean`)
+
+**Events:**
+
+- `wa-load`: Emitted when the image loads successfully.
+- `wa-error`: Emitted when the image fails to load.
+
+**CSS Custom Properties:**
+
+- `--control-box-size`: The size of the icon box.
+- `--icon-size`: The size of the play/pause icons.
+
+**CSS Parts:**
+
+- `control-box`: The container that surrounds the pause/play icons and provides their background.
+
+#### `<wa-animation>`
+
+**Description:** Animate elements declaratively with nearly 100 baked-in presets, or roll your own with custom keyframes. Powered by the Web Animations API.
+
+**Documentation:** https://webawesome.com/docs/components/animation
+
+**Slots:**
+
+- `(default)`: The element to animate. Avoid slotting in more than one element, as subsequent ones will be ignored. To animate multiple elements, either wrap them in a single container or use multiple `<wa-animation>` elements.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `name`: The name of the built-in animation to use. For custom animations, use the `keyframes` prop. (Type: `string`, Default: `'none'`)
+- `play`: Plays the animation. When omitted, the animation will be paused. This attribute will be automatically removed when the animation finishes or gets canceled. (Type: `boolean`, Default: `false`)
+- `delay`: The number of milliseconds to delay the start of the animation. (Type: `number`, Default: `0`)
+- `direction`: Determines the direction of playback as well as the behavior when reaching the end of an iteration. [Learn more](https://developer.mozilla.org/en-US/docs/Web/CSS/animation-direction) (Type: `PlaybackDirection`, Default: `'normal'`)
+- `duration`: The number of milliseconds each iteration of the animation takes to complete. (Type: `number`, Default: `1000`)
+- `easing`: The easing function to use for the animation. This can be a Web Awesome easing function or a custom easing function such as `cubic-bezier(0, 1, .76, 1.14)`. (Type: `string`, Default: `'linear'`)
+- `endDelay` (attribute: `end-delay`): The number of milliseconds to delay after the active period of an animation sequence. (Type: `number`, Default: `0`)
+- `fill`: Sets how the animation applies styles to its target before and after its execution. (Type: `FillMode`, Default: `'auto'`)
+- `iterations`: The number of iterations to run before the animation completes. Defaults to `Infinity`, which loops. (Type: `number`, Default: `Infinity`)
+- `iterationStart` (attribute: `iteration-start`): The offset at which to start the animation, usually between 0 (start) and 1 (end). (Type: `number`, Default: `0`)
+- `keyframes`: The keyframes to use for the animation. If this is set, `name` will be ignored. (Type: `Keyframe[] | undefined`)
+- `playbackRate` (attribute: `playback-rate`): Sets the animation's playback rate. The default is `1`, which plays the animation at a normal speed. Setting this to `2`, for example, will double the animation's speed. A negative value can be used to reverse the animation. This value can be changed without causing the animation to restart. (Type: `number`, Default: `1`)
+- `currentTime`: Gets and sets the current animation time. (Type: `CSSNumberish`)
+
+**Methods:**
+
+- `cancel()`: Clears all keyframe effects caused by this animation and aborts its playback.
+- `finish()`: Sets the playback time to the end of the animation corresponding to the current playback direction.
+
+**Events:**
+
+- `wa-cancel`: Emitted when the animation is canceled.
+- `wa-finish`: Emitted when the animation finishes.
+- `wa-start`: Emitted when the animation starts or restarts.
+
+#### `<wa-avatar>`
+
+**Description:** Avatars represent a person or object with an image, initials, or icon. Use them in lists, comments, and profiles to give users visual context at a glance.
+
+**Documentation:** https://webawesome.com/docs/components/avatar
+
+**Slots:**
+
+- `icon`: The default icon to use when no image or initials are present. Works best with `<wa-icon>`.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `image`: The image source to use for the avatar. (Type: `string`, Default: `''`)
+- `label`: A label to use to describe the avatar to assistive devices. (Type: `string`, Default: `''`)
+- `initials`: Initials to use as a fallback when no image is available (1-2 characters max recommended). (Type: `string`, Default: `''`)
+- `loading`: Indicates how the browser should load the image. (Type: `'eager' | 'lazy'`, Default: `'eager'`)
+- `shape`: The shape of the avatar. (Type: `'circle' | 'square' | 'rounded'`, Default: `'circle'`)
+
+**Events:**
+
+- `wa-error`: The image could not be loaded. This may because of an invalid URL, a temporary network condition, or some unknown cause.
+
+**CSS Custom Properties:**
+
+- `--size`: The size of the avatar.
+
+**CSS Parts:**
+
+- `icon`: The container that wraps the avatar's icon.
+- `initials`: The container that wraps the avatar's initials.
+- `image`: The avatar image. Only shown when the `image` attribute is set.
+
+#### `<wa-badge>`
+
+**Description:** Badges draw attention to adjacent content by displaying a status, count, or label. Use them to highlight notifications, categorize items, or flag new activity.
+
+**Documentation:** https://webawesome.com/docs/components/badge
+
+**Slots:**
+
+- `(default)`: The badge's content.
+- `start`: An element, such as `<wa-icon>`, placed before the label.
+- `end`: An element, such as `<wa-icon>`, placed after the label.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[variantStyles, styles]`)
+- `variant`: The badge's theme variant. Defaults to `brand` if not within another element with a variant. (Type: `'brand' | 'neutral' | 'success' | 'warning' | 'danger'`, Default: `'brand'`)
+- `appearance`: The badge's visual appearance. (Type: `'accent' | 'filled' | 'outlined' | 'filled-outlined'`, Default: `'accent'`)
+- `pill`: Draws a pill-style badge with rounded edges. (Type: `boolean`, Default: `false`)
+- `attention`: Adds an animation to draw attention to the badge. (Type: `'none' | 'pulse' | 'bounce'`, Default: `'none'`)
+
+**CSS Custom Properties:**
+
+- `--pulse-color`: The color of the badge's pulse effect when using `attention="pulse"`.
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+- `start`: The container that wraps the `start` slot.
+- `end`: The container that wraps the `end` slot.
+
+#### `<wa-bar-chart>`
+
+**Description:** Bar charts compare quantities across categories using rectangular bars. They work well for showing rankings, highlighting differences between groups, and tracking changes across time periods.
+
+**Documentation:** https://webawesome.com/docs/components/bar-chart
+
+**Slots:**
+
+- `(default)`: An optional `<script type="application/json">` element containing the Chart.js configuration object.
+
+**Properties:**
+
+- `type`: The type of chart to render. Valid types include `bar`, `line`, `pie`, `doughnut`, `polarArea`, `radar`, `scatter`, and `bubble`. (Type: `ChartType`, Default: `'bar'`)
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles]`)
+- `label`: A label for the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `description`: A description of the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `xLabel`: A label for the x-axis. (Type: `string | null`, Default: `null`)
+- `yLabel`: A label for the y-axis. (Type: `string | null`, Default: `null`)
+- `legendPosition` (attribute: `legend-position`): The position of the legend relative to the chart. (Type: `LayoutPosition | 'start' | 'end'`, Default: `'top'`)
+- `stacked`: Stacks datasets on top of each other along the value axis. (Type: `boolean`, Default: `false`)
+- `indexAxis` (attribute: `index-axis`): The base axis of the dataset. 'x' for vertical bars and 'y' for horizontal bars. (Type: `'x' | 'y'`, Default: `'x'`)
+- `grid`: Which axes to show grid lines on. (Type: `'x' | 'y' | 'both' | 'none'`, Default: `'both'`)
+- `min`: The minimum value for the value axis. (Type: `number | null`, Default: `null`)
+- `max`: The maximum value for the value axis. (Type: `number | null`, Default: `null`)
+- `withoutAnimation` (attribute: `without-animation`): Disables chart animations (Type: `boolean`, Default: `false`)
+- `withoutLegend` (attribute: `without-legend`): Hides the legend (Type: `boolean`, Default: `false`)
+- `withoutTooltip` (attribute: `without-tooltip`): Hides tooltips over data points (Type: `boolean`, Default: `false`)
+- `config`: The Chart.js configuration object. Setting this property will automatically re-render the chart. (Type: `ChartJS['config']`)
+- `plugins`: Additional Chart.js plugins to register for this chart instance. (Type: `array`, Default: `[]`)
+
+**CSS Custom Properties:**
+
+- `--fill-color-1`: Fill color for the first dataset. (Default: `color-mix(in srgb, var(--wa-color-blue-60) 40%, transparent)`)
+- `--fill-color-2`: Fill color for the second dataset. (Default: `color-mix(in srgb, var(--wa-color-pink-60) 40%, transparent)`)
+- `--fill-color-3`: Fill color for the third dataset. (Default: `color-mix(in srgb, var(--wa-color-green-60) 40%, transparent)`)
+- `--fill-color-4`: Fill color for the fourth dataset. (Default: `color-mix(in srgb, var(--wa-color-yellow-60) 40%, transparent)`)
+- `--fill-color-5`: Fill color for the fifth dataset. (Default: `color-mix(in srgb, var(--wa-color-purple-60) 40%, transparent)`)
+- `--fill-color-6`: Fill color for the sixth dataset. (Default: `color-mix(in srgb, var(--wa-color-orange-60) 40%, transparent)`)
+- `--border-color-1`: Border color for the first dataset. (Default: `var(--wa-color-blue-60)`)
+- `--border-color-2`: Border color for the second dataset. (Default: `var(--wa-color-pink-60)`)
+- `--border-color-3`: Border color for the third dataset. (Default: `var(--wa-color-green-60)`)
+- `--border-color-4`: Border color for the fourth dataset. (Default: `var(--wa-color-yellow-60)`)
+- `--border-color-5`: Border color for the fifth dataset. (Default: `var(--wa-color-purple-60)`)
+- `--border-color-6`: Border color for the sixth dataset. (Default: `var(--wa-color-orange-60)`)
+- `--grid-color`: Color of the chart grid lines and axis borders. (Default: `var(--wa-color-neutral-border-quiet)`)
+- `--border-width`: Border width for bars and arcs. (Default: `var(--wa-border-width-s)`)
+- `--border-radius`: Border radius for bar charts. (Default: `var(--wa-border-radius-s)`)
+- `--grid-border-width`: Border width for chart grid lines and axis borders. (Default: `var(--wa-border-width-s)`)
+- `--line-border-width`: Border width for line and radar charts. (Default: `var(--wa-border-width-m)`)
+- `--point-radius`: Radius of data point dots. (Default: `var(--wa-border-width-m)`)
+
+#### `<wa-breadcrumb>`
+
+**Description:** Breadcrumbs display a trail of links that show users where they are in a site's hierarchy. They help users understand the current location and navigate back to parent pages.
+
+**Documentation:** https://webawesome.com/docs/components/breadcrumb
+
+**Slots:**
+
+- `(default)`: One or more breadcrumb items to display.
+- `separator`: The separator to use between breadcrumb items. Works best with `<wa-icon>`.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `label`: The label to use for the breadcrumb control. This will not be shown on the screen, but it will be announced by screen readers and other assistive devices to provide more context for users. (Type: `string`, Default: `''`)
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+
+#### `<wa-breadcrumb-item>`
+
+**Description:** Breadcrumb items represent individual links inside a breadcrumb, typically one per level of the site hierarchy.
+
+**Documentation:** https://webawesome.com/docs/components/breadcrumb-item
+
+**Slots:**
+
+- `(default)`: The breadcrumb item's label.
+- `start`: An element, such as `<wa-icon>`, placed before the label.
+- `end`: An element, such as `<wa-icon>`, placed after the label.
+- `separator`: The separator to use for the breadcrumb item. This will only change the separator for this item. If you want to change it for all items in the group, set the separator on `<wa-breadcrumb>` instead.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `href`: Optional URL to direct the user to when the breadcrumb item is activated. When set, a link will be rendered internally. When unset, a button will be rendered instead. (Type: `string | undefined`)
+- `target`: Tells the browser where to open the link. Only used when `href` is set. (Type: `'_blank' | '_parent' | '_self' | '_top' | undefined`)
+- `rel`: The `rel` attribute to use on the link. Only used when `href` is set. (Type: `string`, Default: `'noreferrer noopener'`)
+
+**CSS Parts:**
+
+- `label`: The breadcrumb item's label.
+- `start`: The container that wraps the `start` slot.
+- `end`: The container that wraps the `end` slot.
+- `separator`: The container that wraps the separator.
+
+#### `<wa-bubble-chart>`
+
+**Description:** Bubble charts add a third dimension to scatter plots by varying the size of each data point. They are useful for visualizing relationships where a third variable adds meaning beyond a simple x/y correlation.
+
+**Documentation:** https://webawesome.com/docs/components/bubble-chart
+
+**Slots:**
+
+- `(default)`: An optional `<script type="application/json">` element containing the Chart.js configuration object.
+
+**Properties:**
+
+- `type`: The type of chart to render. Valid types include `bar`, `line`, `pie`, `doughnut`, `polarArea`, `radar`, `scatter`, and `bubble`. (Type: `ChartType`, Default: `'bubble'`)
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles]`)
+- `label`: A label for the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `description`: A description of the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `xLabel`: A label for the x-axis. (Type: `string | null`, Default: `null`)
+- `yLabel`: A label for the y-axis. (Type: `string | null`, Default: `null`)
+- `legendPosition` (attribute: `legend-position`): The position of the legend relative to the chart. (Type: `LayoutPosition | 'start' | 'end'`, Default: `'top'`)
+- `stacked`: Stacks datasets on top of each other along the value axis. (Type: `boolean`, Default: `false`)
+- `indexAxis` (attribute: `index-axis`): The base axis of the dataset. 'x' for vertical bars and 'y' for horizontal bars. (Type: `'x' | 'y'`, Default: `'x'`)
+- `grid`: Which axes to show grid lines on. (Type: `'x' | 'y' | 'both' | 'none'`, Default: `'both'`)
+- `min`: The minimum value for the value axis. (Type: `number | null`, Default: `null`)
+- `max`: The maximum value for the value axis. (Type: `number | null`, Default: `null`)
+- `withoutAnimation` (attribute: `without-animation`): Disables chart animations (Type: `boolean`, Default: `false`)
+- `withoutLegend` (attribute: `without-legend`): Hides the legend (Type: `boolean`, Default: `false`)
+- `withoutTooltip` (attribute: `without-tooltip`): Hides tooltips over data points (Type: `boolean`, Default: `false`)
+- `config`: The Chart.js configuration object. Setting this property will automatically re-render the chart. (Type: `ChartJS['config']`)
+- `plugins`: Additional Chart.js plugins to register for this chart instance. (Type: `array`, Default: `[]`)
+
+**CSS Custom Properties:**
+
+- `--fill-color-1`: Fill color for the first dataset. (Default: `color-mix(in srgb, var(--wa-color-blue-60) 40%, transparent)`)
+- `--fill-color-2`: Fill color for the second dataset. (Default: `color-mix(in srgb, var(--wa-color-pink-60) 40%, transparent)`)
+- `--fill-color-3`: Fill color for the third dataset. (Default: `color-mix(in srgb, var(--wa-color-green-60) 40%, transparent)`)
+- `--fill-color-4`: Fill color for the fourth dataset. (Default: `color-mix(in srgb, var(--wa-color-yellow-60) 40%, transparent)`)
+- `--fill-color-5`: Fill color for the fifth dataset. (Default: `color-mix(in srgb, var(--wa-color-purple-60) 40%, transparent)`)
+- `--fill-color-6`: Fill color for the sixth dataset. (Default: `color-mix(in srgb, var(--wa-color-orange-60) 40%, transparent)`)
+- `--border-color-1`: Border color for the first dataset. (Default: `var(--wa-color-blue-60)`)
+- `--border-color-2`: Border color for the second dataset. (Default: `var(--wa-color-pink-60)`)
+- `--border-color-3`: Border color for the third dataset. (Default: `var(--wa-color-green-60)`)
+- `--border-color-4`: Border color for the fourth dataset. (Default: `var(--wa-color-yellow-60)`)
+- `--border-color-5`: Border color for the fifth dataset. (Default: `var(--wa-color-purple-60)`)
+- `--border-color-6`: Border color for the sixth dataset. (Default: `var(--wa-color-orange-60)`)
+- `--grid-color`: Color of the chart grid lines and axis borders. (Default: `var(--wa-color-neutral-border-quiet)`)
+- `--border-width`: Border width for bars and arcs. (Default: `var(--wa-border-width-s)`)
+- `--border-radius`: Border radius for bar charts. (Default: `var(--wa-border-radius-s)`)
+- `--grid-border-width`: Border width for chart grid lines and axis borders. (Default: `var(--wa-border-width-s)`)
+- `--line-border-width`: Border width for line and radar charts. (Default: `var(--wa-border-width-m)`)
+- `--point-radius`: Radius of data point dots. (Default: `var(--wa-border-width-m)`)
+
+#### `<wa-button>`
+
+**Description:** Buttons represent actions the user can take, such as submitting a form, opening a dialog, or navigating to another page.
+
+**Documentation:** https://webawesome.com/docs/components/button
+
+**Slots:**
+
+- `(default)`: The button's label.
+- `start`: An element, such as `<wa-icon>`, placed before the label.
+- `end`: An element, such as `<wa-icon>`, placed after the label.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles, variantStyles, sizeStyles]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `variant`: The button's theme variant. Defaults to `neutral` if not within another element with a variant. (Type: `'neutral' | 'brand' | 'success' | 'warning' | 'danger'`, Default: `'neutral'`)
+- `appearance`: The button's visual appearance. (Type: `'accent' | 'filled' | 'outlined' | 'filled-outlined' | 'plain'`, Default: `'accent'`)
+- `size`: The button's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `withCaret` (attribute: `with-caret`): Draws the button with a caret. Used to indicate that the button triggers a dropdown menu or similar behavior. (Type: `boolean`, Default: `false`)
+- `withStart` (attribute: `with-start`): Only required for SSR. Set to `true` if you're slotting in a `start` element so the server-rendered markup includes the start slot before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withEnd` (attribute: `with-end`): Only required for SSR. Set to `true` if you're slotting in an `end` element so the server-rendered markup includes the end slot before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `disabled`: Disables the button. (Type: `boolean`, Default: `false`)
+- `loading`: Draws the button in a loading state. (Type: `boolean`, Default: `false`)
+- `pill`: Draws a pill-style button with rounded edges. (Type: `boolean`, Default: `false`)
+- `type`: The type of button. Note that the default value is `button` instead of `submit`, which is opposite of how native `<button>` elements behave. When the type is `submit`, the button will submit the surrounding form. (Type: `'button' | 'submit' | 'reset'`, Default: `'button'`)
+- `name`: The name of the button, submitted as a name/value pair with form data, but only when this button is the submitter. This attribute is ignored when `href` is present. (Type: `string | null`, Default: `null`)
+- `value`: The value of the button, submitted as a pair with the button's name as part of the form data, but only when this button is the submitter. This attribute is ignored when `href` is present. (Type: `string`)
+- `href`: When set, the underlying button will be rendered as an `<a>` with this `href` instead of a `<button>`. (Type: `string`)
+- `target`: Tells the browser where to open the link. Only used when `href` is present. (Type: `'_blank' | '_parent' | '_self' | '_top'`)
+- `rel`: When using `href`, this attribute will map to the underlying link's `rel` attribute. (Type: `string | undefined`)
+- `download`: Tells the browser to download the linked file as this filename. Only used when `href` is present. (Type: `string | undefined`)
+- `formAction` (attribute: `formaction`): Used to override the form owner's `action` attribute. (Type: `string`)
+- `formEnctype` (attribute: `formenctype`): Used to override the form owner's `enctype` attribute. (Type: `'application/x-www-form-urlencoded' | 'multipart/form-data' | 'text/plain'`)
+- `formMethod` (attribute: `formmethod`): Used to override the form owner's `method` attribute. (Type: `'post' | 'get'`)
+- `formNoValidate` (attribute: `formnovalidate`): Used to override the form owner's `novalidate` attribute. (Type: `boolean`)
+- `formTarget` (attribute: `formtarget`): Used to override the form owner's `target` attribute. (Type: `'_self' | '_blank' | '_parent' | '_top' | string`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+- `validationTarget`: Override this to change where constraint validation popups are anchored. (Type: `undefined | HTMLElement`)
+
+**Methods:**
+
+- `click()`: Simulates a click on the button.
+- `focus(options: FocusOptions)`: Sets focus on the button.
+- `blur()`: Removes focus from the button.
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `blur`: Emitted when the button loses focus.
+- `focus`: Emitted when the button gains focus.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+- `start`: The container that wraps the `start` slot.
+- `label`: The button's label.
+- `end`: The container that wraps the `end` slot.
+- `caret`: The button's caret icon, a `<wa-icon>` element.
+- `spinner`: The spinner that shows when the button is in the loading state.
+
+**CSS States:**
+
+- `disabled`: Applied when the button is disabled.
+- `icon-button`: Applied when the button contains only a `<wa-icon>` with no other content.
+- `link`: Applied when the button is rendered as a link (i.e. `href` is set).
+- `loading`: Applied when the button is in the loading state.
+
+#### `<wa-button-group>`
+
+**Description:** Button groups combine related buttons into a single visual unit. Use them for toolbars, segmented controls, or any set of actions that belong together.
+
+**Documentation:** https://webawesome.com/docs/components/button-group
+
+**Slots:**
+
+- `(default)`: One or more `<wa-button>` elements to display in the button group.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles]`)
+- `label`: A label to use for the button group. This won't be displayed on the screen, but it will be announced by assistive devices when interacting with the control and is strongly recommended. (Type: `string`, Default: `''`)
+- `orientation`: The button group's orientation. (Type: `'horizontal' | 'vertical'`, Default: `'horizontal'`)
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+
+#### `<wa-callout>`
+
+**Description:** Callouts display important messages inline with surrounding content. Use them to highlight tips, warnings, errors, or other information users should not miss.
+
+**Documentation:** https://webawesome.com/docs/components/callout
+
+**Slots:**
+
+- `(default)`: The callout's main content.
+- `icon`: An icon to show in the callout. Works best with `<wa-icon>`.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles, variantStyles, sizeStyles]`)
+- `variant`: The callout's theme variant. Defaults to `brand` if not within another element with a variant. (Type: `'brand' | 'neutral' | 'success' | 'warning' | 'danger'`, Default: `'brand'`)
+- `appearance`: The callout's visual appearance. (Type: `'accent' | 'filled' | 'outlined' | 'plain' | 'filled-outlined'`)
+- `size`: The callout's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+
+**CSS Parts:**
+
+- `icon`: The container that wraps the optional icon.
+- `message`: The container that wraps the callout's main content.
+
+#### `<wa-card>`
+
+**Description:** Cards group related content and actions inside a bordered container. Use them to present products, articles, user profiles, or any self-contained unit of information.
+
+**Documentation:** https://webawesome.com/docs/components/card
+
+**Slots:**
+
+- `(default)`: The card's main content.
+- `header`: An optional header for the card.
+- `footer`: An optional footer for the card.
+- `media`: An optional media section to render at the start of the card.
+- `actions`: An optional actions section to render at the end for the horizontal card.
+- `header-actions`: An optional actions section to render in the header of the vertical card.
+- `footer-actions`: An optional actions section to render in the footer of the vertical card.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[sizeStyles, styles]`)
+- `appearance`: The card's visual appearance. (Type: `'accent' | 'filled' | 'outlined' | 'filled-outlined' | 'plain'`, Default: `'outlined'`)
+- `withHeader` (attribute: `with-header`): Only required for SSR. Set to `true` if you're slotting in a `header` element so the server-rendered markup includes the header before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withMedia` (attribute: `with-media`): Only required for SSR. Set to `true` if you're slotting in a `media` element so the server-rendered markup includes the media before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withFooter` (attribute: `with-footer`): Only required for SSR. Set to `true` if you're slotting in a `footer` element so the server-rendered markup includes the footer before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `orientation`: Renders the card's orientation * (Type: `'horizontal' | 'vertical'`, Default: `'vertical'`)
+
+**CSS Custom Properties:**
+
+- `--spacing`: The amount of space around and between sections of the card. Expects a single value. (Default: `var(--wa-space-l)`)
+
+**CSS Parts:**
+
+- `media`: The container that wraps the card's media.
+- `header`: The container that wraps the card's header.
+- `body`: The container that wraps the card's main content.
+- `footer`: The container that wraps the card's footer.
+
+#### `<wa-carousel>`
+
+**Description:** Carousels display a series of content slides along a horizontal or vertical axis, one or more at a time. Users can navigate between slides with controls, pagination, or autoplay.
+
+**Documentation:** https://webawesome.com/docs/components/carousel
+
+**Slots:**
+
+- `(default)`: The carousel's main content, one or more `<wa-carousel-item>` elements.
+- `next-icon`: Optional next icon to use instead of the default. Works best with `<wa-icon>`.
+- `previous-icon`: Optional previous icon to use instead of the default. Works best with `<wa-icon>`.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `loop`: When set, allows the user to navigate the carousel in the same direction indefinitely. (Type: `boolean`, Default: `false`)
+- `navigation`: When set, show the carousel's navigation. (Type: `boolean`, Default: `false`)
+- `pagination`: When set, show the carousel's pagination indicators. (Type: `boolean`, Default: `false`)
+- `autoplay`: When set, the slides will scroll automatically when the user is not interacting with them. (Type: `boolean`, Default: `false`)
+- `autoplayInterval` (attribute: `autoplay-interval`): Specifies the amount of time, in milliseconds, between each automatic scroll. (Type: `number`, Default: `3000`)
+- `slidesPerPage` (attribute: `slides-per-page`): Specifies how many slides should be shown at a given time. (Type: `number`, Default: `1`)
+- `slidesPerMove` (attribute: `slides-per-move`): Specifies the number of slides the carousel will advance when scrolling, useful when specifying a `slides-per-page` greater than one. It can't be higher than `slides-per-page`. (Type: `number`, Default: `1`)
+- `orientation`: Specifies the orientation in which the carousel will lay out. (Type: `'horizontal' | 'vertical'`, Default: `'horizontal'`)
+- `mouseDragging` (attribute: `mouse-dragging`): When set, it is possible to scroll through the slides by dragging them with the mouse. (Type: `boolean`, Default: `false`)
+
+**Methods:**
+
+- `previous(behavior: ScrollBehavior)`: Move the carousel backward by `slides-per-move` slides.
+- `next(behavior: ScrollBehavior)`: Move the carousel forward by `slides-per-move` slides.
+- `goToSlide(index: number, behavior: ScrollBehavior)`: Scrolls the carousel to the slide specified by `index`.
+
+**Events:**
+
+- `wa-slide-change`: Emitted when the active slide changes.
+
+**CSS Custom Properties:**
+
+- `--aspect-ratio`: The aspect ratio of each slide. (Default: `16/9`)
+- `--scroll-hint`: The amount of padding to apply to the scroll area, allowing adjacent slides to become partially visible as a scroll hint.
+- `--slide-gap`: The space between each slide. (Default: `var(--wa-space-m)`)
+
+**CSS Parts:**
+
+- `base`: The carousel's internal wrapper.
+- `scroll-container`: The scroll container that wraps the slides.
+- `pagination`: The pagination indicators wrapper.
+- `pagination-item`: The pagination indicator.
+- `pagination-item-active`: Applied when the item is active.
+- `navigation`: The navigation wrapper.
+- `navigation-button`: The navigation button.
+- `navigation-button-previous`: Applied to the previous button.
+- `navigation-button-next`: Applied to the next button.
+
+#### `<wa-carousel-item>`
+
+**Description:** Carousel items represent individual slides within a carousel.
+
+**Documentation:** https://webawesome.com/docs/components/carousel-item
+
+**Slots:**
+
+- `(default)`: The carousel item's content..
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+
+**CSS Custom Properties:**
+
+- `--aspect-ratio`: The slide's aspect ratio. Inherited from the carousel by default.
+
+#### `<wa-chart>`
+
+**Description:** Charts provide a flexible wrapper around Chart.js for building themed data visualizations. Use this component for advanced configuration such as mixed chart types, custom plugins, and direct Chart.js instance access.
+
+**Documentation:** https://webawesome.com/docs/components/chart
+
+**Slots:**
+
+- `(default)`: An optional `<script type="application/json">` element containing the Chart.js configuration object.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles]`)
+- `label`: A label for the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `description`: A description of the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `type`: The type of chart to render. Valid types include `bar`, `line`, `pie`, `doughnut`, `polarArea`, `radar`, `scatter`, and `bubble`. (Type: `ChartType`, Default: `'bar'`)
+- `xLabel`: A label for the x-axis. (Type: `string | null`, Default: `null`)
+- `yLabel`: A label for the y-axis. (Type: `string | null`, Default: `null`)
+- `legendPosition` (attribute: `legend-position`): The position of the legend relative to the chart. (Type: `LayoutPosition | 'start' | 'end'`, Default: `'top'`)
+- `stacked`: Stacks datasets on top of each other along the value axis. (Type: `boolean`, Default: `false`)
+- `indexAxis` (attribute: `index-axis`): The base axis of the dataset. 'x' for vertical bars and 'y' for horizontal bars. (Type: `'x' | 'y'`, Default: `'x'`)
+- `grid`: Which axes to show grid lines on. (Type: `'x' | 'y' | 'both' | 'none'`, Default: `'both'`)
+- `min`: The minimum value for the value axis. (Type: `number | null`, Default: `null`)
+- `max`: The maximum value for the value axis. (Type: `number | null`, Default: `null`)
+- `withoutAnimation` (attribute: `without-animation`): Disables chart animations (Type: `boolean`, Default: `false`)
+- `withoutLegend` (attribute: `without-legend`): Hides the legend (Type: `boolean`, Default: `false`)
+- `withoutTooltip` (attribute: `without-tooltip`): Hides tooltips over data points (Type: `boolean`, Default: `false`)
+- `config`: The Chart.js configuration object. Setting this property will automatically re-render the chart. (Type: `ChartJS['config']`)
+- `plugins`: Additional Chart.js plugins to register for this chart instance. (Type: `array`, Default: `[]`)
+
+**CSS Custom Properties:**
+
+- `--fill-color-1`: Fill color for the first dataset. (Default: `color-mix(in srgb, var(--wa-color-blue-60) 40%, transparent)`)
+- `--fill-color-2`: Fill color for the second dataset. (Default: `color-mix(in srgb, var(--wa-color-pink-60) 40%, transparent)`)
+- `--fill-color-3`: Fill color for the third dataset. (Default: `color-mix(in srgb, var(--wa-color-green-60) 40%, transparent)`)
+- `--fill-color-4`: Fill color for the fourth dataset. (Default: `color-mix(in srgb, var(--wa-color-yellow-60) 40%, transparent)`)
+- `--fill-color-5`: Fill color for the fifth dataset. (Default: `color-mix(in srgb, var(--wa-color-purple-60) 40%, transparent)`)
+- `--fill-color-6`: Fill color for the sixth dataset. (Default: `color-mix(in srgb, var(--wa-color-orange-60) 40%, transparent)`)
+- `--border-color-1`: Border color for the first dataset. (Default: `var(--wa-color-blue-60)`)
+- `--border-color-2`: Border color for the second dataset. (Default: `var(--wa-color-pink-60)`)
+- `--border-color-3`: Border color for the third dataset. (Default: `var(--wa-color-green-60)`)
+- `--border-color-4`: Border color for the fourth dataset. (Default: `var(--wa-color-yellow-60)`)
+- `--border-color-5`: Border color for the fifth dataset. (Default: `var(--wa-color-purple-60)`)
+- `--border-color-6`: Border color for the sixth dataset. (Default: `var(--wa-color-orange-60)`)
+- `--grid-color`: Color of the chart grid lines and axis borders. (Default: `var(--wa-color-neutral-border-quiet)`)
+- `--border-width`: Border width for bars and arcs. (Default: `var(--wa-border-width-s)`)
+- `--border-radius`: Border radius for bar charts. (Default: `var(--wa-border-radius-s)`)
+- `--grid-border-width`: Border width for chart grid lines and axis borders. (Default: `var(--wa-border-width-s)`)
+- `--line-border-width`: Border width for line and radar charts. (Default: `var(--wa-border-width-m)`)
+- `--point-radius`: Radius of data point dots. (Default: `var(--wa-border-width-m)`)
+
+#### `<wa-checkbox>`
+
+**Description:** Checkboxes let users toggle an option on or off, or select multiple items from a list. They also support an indeterminate state for partial selections in groups.
+
+**Documentation:** https://webawesome.com/docs/components/checkbox
+
+**Slots:**
+
+- `(default)`: The checkbox's label.
+- `hint`: Text that describes how to use the checkbox. Alternatively, you can use the `hint` attribute.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[formControlStyles, sizeStyles, styles]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `name`: The name of the checkbox, submitted as a name/value pair with form data. (Type: `string | null`, Default: `null`)
+- `value`: The value of the checkbox, submitted as a name/value pair with form data. (Type: `string | null`)
+- `size`: The checkbox's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `disabled`: Disables the checkbox. (Type: `boolean`, Default: `false`)
+- `indeterminate`: Draws the checkbox in an indeterminate state. This is usually applied to checkboxes that represents a "select all/none" behavior when associated checkboxes have a mix of checked and unchecked states. (Type: `boolean`, Default: `false`)
+- `checked`: Draws the checkbox in a checked state.
+- `defaultChecked` (attribute: `checked`): The default value of the form control. Primarily used for resetting the form control. (Type: `boolean`)
+- `required`: Makes the checkbox a required field. (Type: `boolean`, Default: `false`)
+- `hint`: The checkbox's hint. If you need to display HTML, use the `hint` slot instead. (Type: `string`, Default: `''`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+- `validationTarget`: Override this to change where constraint validation popups are anchored. (Type: `undefined | HTMLElement`)
+
+**Methods:**
+
+- `click()`: Simulates a click on the checkbox.
+- `focus(options: FocusOptions)`: Sets focus on the checkbox.
+- `blur()`: Removes focus from the checkbox.
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `change`: Emitted when the checked state changes.
+- `blur`: Emitted when the checkbox loses focus.
+- `focus`: Emitted when the checkbox gains focus.
+- `input`: Emitted when the checkbox receives input.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Custom Properties:**
+
+- `--checked-icon-color`: The color of the checked and indeterminate icons.
+- `--checked-icon-scale`: The size of the checked and indeterminate icons relative to the checkbox.
+
+**CSS Parts:**
+
+- `base`: The component's label .
+- `control`: The square container that wraps the checkbox's checked state.
+- `checked-icon`: The checked icon, a `<wa-icon>` element.
+- `indeterminate-icon`: The indeterminate icon, a `<wa-icon>` element.
+- `label`: The container that wraps the checkbox's label.
+- `hint`: The hint's wrapper.
+
+**CSS States:**
+
+- `checked`: Applied when the checkbox is checked.
+- `disabled`: Applied when the checkbox is disabled.
+- `indeterminate`: Applied when the checkbox is in an indeterminate state.
+
+#### `<wa-color-picker>`
+
+**Description:** Color pickers let users choose a color from a visual palette or by entering a value. They support HEX, RGB, HSL, and HSV formats with optional alpha channel and swatch presets.
+
+**Documentation:** https://webawesome.com/docs/components/color-picker
+
+**Slots:**
+
+- `label`: The color picker's form label. Alternatively, you can use the `label` attribute.
+- `hint`: The color picker's form hint. Alternatively, you can use the `hint` attribute.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[visuallyHidden, sizeStyles, formControlStyles, styles]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `validationTarget`: Override this to change where constraint validation popups are anchored. (Type: `undefined | HTMLElement`)
+- `value`: The current value of the color picker. The value's format will vary based the `format` attribute. To get the value in a specific format, use the `getFormattedValue()` method. The value is submitted as a name/value pair with form data.
+- `defaultValue` (attribute: `value`): The default value of the form control. Primarily used for resetting the form control. (Type: `string | null`)
+- `withLabel` (attribute: `with-label`): Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup includes the label before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withHint` (attribute: `with-hint`): Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup includes the hint before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `label`: The color picker's label. This will not be displayed, but it will be announced by assistive devices. If you need to display HTML, you can use the `label` slot` instead. (Type: `string`, Default: `''`)
+- `hint`: The color picker's hint. If you need to display HTML, use the `hint` slot instead. (Type: `string`, Default: `''`)
+- `format`: The format to use. If opacity is enabled, these will translate to HEXA, RGBA, HSLA, and HSVA respectively. The color picker will accept user input in any format (including CSS color names) and convert it to the desired format. (Type: `'hex' | 'rgb' | 'hsl' | 'hsv'`, Default: `'hex'`)
+- `size`: Determines the size of the color picker's trigger (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `placement`: The preferred placement of the color picker's popup. Note that the actual placement will vary as configured to keep the panel inside of the viewport. (Type: `| 'top'     | 'top-start'     | 'top-end'     | 'bottom'     | 'bottom-start'     | 'bottom-end'     | 'right'     | 'right-start'     | 'right-end'     | 'left'     | 'left-start'     | 'left-end'`, Default: `'bottom-start'`)
+- `withoutFormatToggle` (attribute: `without-format-toggle`): Removes the button that lets users toggle between format. (Type: `boolean`, Default: `false`)
+- `name`: The name of the form control, submitted as a name/value pair with form data. (Type: `string | null`, Default: `null`)
+- `disabled`: Disables the color picker. (Type: `boolean`, Default: `false`)
+- `open`: Indicates whether or not the popup is open. You can toggle this attribute to show and hide the popup, or you can use the `show()` and `hide()` methods and this attribute will reflect the popup's open state. (Type: `boolean`, Default: `false`)
+- `opacity`: Shows the opacity slider. Enabling this will cause the formatted value to be HEXA, RGBA, or HSLA. (Type: `boolean`, Default: `false`)
+- `uppercase`: By default, values are lowercase. With this attribute, values will be uppercase instead. (Type: `boolean`, Default: `false`)
+- `swatches`: One or more predefined color swatches to display as presets in the color picker. Can include any format the color picker can parse, including HEX(A), RGB(A), HSL(A), HSV(A), and CSS color names. Each color must be separated by a semicolon (`;`). Alternatively, you can pass an array of color values or an array of `{ color, label }` objects to this property using JavaScript. When using objects with labels, the label will be used for the swatch's accessible name instead of the raw color value. (Type: `string | string[] | WaColorPickerSwatch[]`, Default: `''`)
+- `required`: Makes the color picker a required field. (Type: `boolean`, Default: `false`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+
+**Methods:**
+
+- `getHexString(hue: number, saturation: number, brightness: number, alpha: unknown)`: Generates a hex string from HSV values. Hue must be 0-360. All other arguments must be 0-100.
+- `focus(options: FocusOptions)`: Sets focus on the color picker.
+- `blur()`: Removes focus from the color picker.
+- `getFormattedValue(format: 'hex' | 'hexa' | 'rgb' | 'rgba' | 'hsl' | 'hsla' | 'hsv' | 'hsva')`: Returns the current value as a string in the specified format.
+- `reportValidity()`: Checks for validity and shows the browser's validation message if the control is invalid.
+- `show()`: Shows the color picker panel.
+- `hide()`: Hides the color picker panel
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `change`: Emitted when the color picker's value changes.
+- `input`: Emitted when the color picker receives input.
+- `wa-show`: No description.
+- `wa-after-show`: No description.
+- `wa-hide`: No description.
+- `wa-after-hide`: No description.
+- `blur`: Emitted when the color picker loses focus.
+- `focus`: Emitted when the color picker receives focus.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Custom Properties:**
+
+- `--grid-width`: The width of the color grid.
+- `--grid-height`: The height of the color grid.
+- `--grid-handle-size`: The size of the color grid's handle.
+- `--slider-height`: The height of the hue and alpha sliders.
+- `--slider-handle-size`: The diameter of the slider's handle.
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+- `trigger`: The color picker's dropdown trigger.
+- `swatches`: The container that holds the swatches.
+- `swatch`: Each individual swatch.
+- `grid`: The color grid.
+- `grid-handle`: The color grid's handle.
+- `slider`: Hue and opacity sliders.
+- `slider-handle`: Hue and opacity slider handles.
+- `hue-slider`: The hue slider.
+- `hue-slider-handle`: The hue slider's handle.
+- `opacity-slider`: The opacity slider.
+- `opacity-slider-handle`: The opacity slider's handle.
+- `preview`: The preview color.
+- `input`: The text input.
+- `eyedropper-button`: The eye dropper button.
+- `eyedropper-button__base`: The eye dropper button's exported `button` part.
+- `eyedropper-button__start`: The eye dropper button's exported `start` part.
+- `eyedropper-button__label`: The eye dropper button's exported `label` part.
+- `eyedropper-button__end`: The eye dropper button's exported `end` part.
+- `eyedropper-button__caret`: The eye dropper button's exported `caret` part.
+- `format-button`: The format button.
+- `format-button__base`: The format button's exported `button` part.
+- `format-button__start`: The format button's exported `start` part.
+- `format-button__label`: The format button's exported `label` part.
+- `format-button__end`: The format button's exported `end` part.
+- `format-button__caret`: The format button's exported `caret` part.
+
+#### `<wa-combobox>`
+
+**Description:** Comboboxes combine a text input with a listbox, allowing users to filter and select from predefined options or enter custom values.
+
+**Documentation:** https://webawesome.com/docs/components/combobox
+
+**Slots:**
+
+- `(default)`: The listbox options. Must be `<wa-option>` elements. You can use `<wa-divider>` to group items visually.
+- `label`: The input's label. Alternatively, you can use the `label` attribute.
+- `start`: An element, such as `<wa-icon>`, placed at the start of the combobox.
+- `end`: An element, such as `<wa-icon>`, placed at the end of the combobox.
+- `clear-icon`: An icon to use in lieu of the default clear icon.
+- `expand-icon`: The icon to show when the control is expanded and collapsed. Rotates on open and close.
+- `hint`: Text that describes how to use the input. Alternatively, you can use the `hint` attribute.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles, formControlStyles, sizeStyles]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `validationTarget`: Where to anchor native constraint validation (Type: `undefined | HTMLElement`)
+- `inputValue`: The current text value in the input field. (Type: `string`, Default: `''`)
+- `name`: The name of the combobox, submitted as a name/value pair with form data. (Type: `string | null`, Default: `''`)
+- `value`: The combobox's value. This will be a string for single select or an array for multi-select.
+- `size`: The combobox's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `placeholder`: Placeholder text to show as a hint when the combobox is empty. (Type: `string`, Default: `''`)
+- `multiple`: Allows more than one option to be selected. (Type: `boolean`, Default: `false`)
+- `maxOptionsVisible` (attribute: `max-options-visible`): The maximum number of selected options to show when `multiple` is true. After the maximum, "+n" will be shown to indicate the number of additional items that are selected. Set to 0 to remove the limit. (Type: `number`, Default: `3`)
+- `disabled`: Disables the combobox control. (Type: `boolean`, Default: `false`)
+- `withClear` (attribute: `with-clear`): Adds a clear button when the combobox is not empty. (Type: `boolean`, Default: `false`)
+- `open`: Indicates whether or not the combobox is open. You can toggle this attribute to show and hide the menu, or you can use the `show()` and `hide()` methods and this attribute will reflect the combobox's open state. (Type: `boolean`, Default: `false`)
+- `appearance`: The combobox's visual appearance. (Type: `'filled' | 'outlined' | 'filled-outlined'`, Default: `'outlined'`)
+- `pill`: Draws a pill-style combobox with rounded edges. (Type: `boolean`, Default: `false`)
+- `label`: The combobox's label. If you need to display HTML, use the `label` slot instead. (Type: `string`, Default: `''`)
+- `placement`: The preferred placement of the combobox's menu. Note that the actual placement may vary as needed to keep the listbox inside of the viewport. (Type: `'top' | 'bottom'`, Default: `'bottom'`)
+- `hint`: The combobox's hint. If you need to display HTML, use the `hint` slot instead. (Type: `string`, Default: `''`)
+- `withLabel` (attribute: `with-label`): Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup includes the label before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withHint` (attribute: `with-hint`): Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup includes the hint before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `required`: The combobox's required attribute. (Type: `boolean`, Default: `false`)
+- `allowCustomValue` (attribute: `allow-custom-value`): When true, allows the user to enter a value that doesn't match any of the options. Only applies to single-select comboboxes. When false, the combobox will only accept values that match an option. (Type: `boolean`, Default: `false`)
+- `allowCreate` (attribute: `allow-create`): When true, if the user types text that doesn't match any existing option, a "Create [value]" option appears in the listbox. Selecting it creates a new `<wa-option>` in the DOM and selects it. A cancelable `wa-create` event fires before creation. (Type: `boolean`, Default: `false`)
+- `filter`: A function that customizes how options are filtered based on the input value. The function receives the option and the current input query string. Return `true` to include the option in the filtered list, `false` to exclude. By default, options are filtered by checking if the option's label contains the query (case-insensitive). (Type: `((option: WaOption, query: string) => boolean) | null`, Default: `null`)
+- `autocapitalize`: Controls whether and how text input is automatically capitalized as it is entered/edited by the user. (Type: `'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters'`)
+- `autocorrect`: Indicates whether the browser's autocorrect feature is on or off. When set as an attribute, use `"off"` or `"on"`. When set as a property, use `true` or `false`. (Type: `boolean`)
+- `inputmode`: Tells the browser what type of data will be entered by the user, allowing it to display the appropriate virtual keyboard on supportive devices. (Type: `'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url'`)
+- `enterkeyhint`: Used to customize the label or icon of the Enter key on virtual keyboards. (Type: `'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send'`)
+- `spellcheck`: Enables spell checking on the combobox. (Type: `boolean`, Default: `false`)
+- `getTag`: A function that customizes the tags to be rendered when multiple=true. The first argument is the option, the second is the current tag's index.  The function should return either a Lit TemplateResult or a string containing trusted HTML of the symbol to render at the specified value. (Type: `(option: WaOption, index: number) => TemplateResult | string | HTMLElement`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+
+**Methods:**
+
+- `show()`: Shows the listbox.
+- `hide()`: Hides the listbox.
+- `focus(options: FocusOptions)`: Sets focus on the control.
+- `blur()`: Removes focus from the control.
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `input`: Emitted when the control receives input.
+- `change`: Emitted when the control's value changes.
+- `focus`: Emitted when the control gains focus.
+- `blur`: Emitted when the control loses focus.
+- `wa-clear`: Emitted when the control's value is cleared.
+- `wa-show`: Emitted when the combobox's menu opens.
+- `wa-after-show`: Emitted after the combobox's menu opens and all animations are complete.
+- `wa-hide`: Emitted when the combobox's menu closes.
+- `wa-after-hide`: Emitted after the combobox's menu closes and all animations are complete.
+- `wa-create`: Emitted when the user selects the "create" option. Call `event.preventDefault()` to handle creation yourself. The event `detail` contains `{ inputValue: string }`.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Custom Properties:**
+
+- `--show-duration`: The duration of the show animation. (Default: `100ms`)
+- `--hide-duration`: The duration of the hide animation. (Default: `100ms`)
+- `--tag-max-size`: When using `multiple`, the max size of tags before their content is truncated. (Default: `10ch`)
+
+**CSS Parts:**
+
+- `form-control`: The form control that wraps the label, input, and hint.
+- `form-control-label`: The label's wrapper.
+- `form-control-input`: The combobox's wrapper.
+- `hint`: The hint's wrapper.
+- `combobox`: The container the wraps the start, end, value, clear icon, and expand button.
+- `start`: The container that wraps the `start` slot.
+- `end`: The container that wraps the `end` slot.
+- `combobox-input`: The text input element.
+- `listbox`: The listbox container where options are slotted.
+- `tags`: The container that houses option tags when `multiselect` is used.
+- `tag`: The individual tags that represent each multiselect option.
+- `tag__content`: The tag's content part.
+- `tag__remove-button`: The tag's remove button.
+- `tag__remove-button__base`: The tag's remove button base part.
+- `clear-button`: The clear button.
+- `expand-icon`: The container that wraps the expand icon.
+
+**CSS States:**
+
+- `blank`: The combobox is empty.
+- `disabled`: The combobox is disabled.
+
+#### `<wa-comparison>`
+
+**Description:** Comparisons show the visual differences between two pieces of similar content using a draggable divider. Use them for before/after images, design revisions, or side-by-side previews.
+
+**Documentation:** https://webawesome.com/docs/components/comparison
+
+**Slots:**
+
+- `before`: The before content, often an `<img>` or `<svg>` element.
+- `after`: The after content, often an `<img>` or `<svg>` element.
+- `handle`: The icon used inside the handle.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `position`: The position of the divider as a percentage. (Type: `number`, Default: `50`)
+
+**Events:**
+
+- `change`: Emitted when the position changes.
+
+**CSS Custom Properties:**
+
+- `--divider-width`: The width of the dividing line.
+- `--handle-size`: The size of the compare handle.
+
+**CSS Parts:**
+
+- `base`: The container that wraps the before and after content.
+- `before`: The container that wraps the before content.
+- `after`: The container that wraps the after content.
+- `divider`: The divider that separates the before and after content.
+- `handle`: The handle that the user drags to expose the after content.
+
+**CSS States:**
+
+- `dragging`: Applied when the comparison is being dragged.
+
+#### `<wa-copy-button>`
+
+**Description:** Copy buttons copy text to the clipboard when the user activates them. They provide built-in success and error feedback so users know the copy worked.
+
+**Documentation:** https://webawesome.com/docs/components/copy-button
+
+**Slots:**
+
+- `(default)`: The trigger element. By default, a copy icon button is rendered so this is optional. If desired, you can slot in a custom element such as `<wa-button>` or `<button>`.
+- `copy-icon`: The icon to show in the default copy state. Works best with `<wa-icon>`.
+- `success-icon`: The icon to show when the content is copied. Works best with `<wa-icon>`.
+- `error-icon`: The icon to show when a copy error occurs. Works best with `<wa-icon>`.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[hostStyles, visuallyHidden, styles]`)
+- `value`: The text value to copy. (Type: `string`, Default: `''`)
+- `from`: An id that references an element in the same document from which data will be copied. If both this and `value` are present, this value will take precedence. By default, the target element's `textContent` will be copied. To copy an attribute, append the attribute name wrapped in square brackets, e.g. `from="el[value]"`. To copy a property, append a dot and the property name, e.g. `from="el.value"`. (Type: `string`, Default: `''`)
+- `disabled`: Disables the copy button. (Type: `boolean`, Default: `false`)
+- `copyLabel` (attribute: `copy-label`): A custom label to use as the accessible name and tooltip text in the default copy state. (Type: `string`, Default: `''`)
+- `successLabel` (attribute: `success-label`): A custom label to show in the tooltip after copying. (Type: `string`, Default: `''`)
+- `errorLabel` (attribute: `error-label`): A custom label to show in the tooltip when a copy error occurs. (Type: `string`, Default: `''`)
+- `feedbackDuration` (attribute: `feedback-duration`): The length of time to show feedback before restoring the default trigger. (Type: `number`, Default: `1000`)
+- `tooltipPlacement` (attribute: `tooltip-placement`): The preferred placement of the tooltip. (Type: `'top' | 'right' | 'bottom' | 'left'`, Default: `'top'`)
+- `tooltip`: Controls the built-in tooltip. `full` (default) shows the tooltip on hover and focus and during copy feedback. `copy` keeps the tooltip silent on hover/focus and only shows it briefly to confirm a successful or failed copy. `none` disables the tooltip entirely. Applies to both the default and custom triggers. (Type: `'full' | 'copy' | 'none'`, Default: `'full'`)
+
+**Events:**
+
+- `wa-copy`: Emitted when the data has been copied.
+- `wa-error`: Emitted when the data could not be copied.
+
+**CSS Parts:**
+
+- `button`: The internal `<button>` element.
+- `copy-icon`: The container that holds the copy icon.
+- `success-icon`: The container that holds the success icon.
+- `error-icon`: The container that holds the error icon.
+- `feedback`: The internal `<wa-tooltip>` element.
+
+**CSS States:**
+
+- `success`: Applied when the copy operation succeeds.
+- `error`: Applied when the copy operation fails.
+
+#### `<wa-details>`
+
+**Description:** Details display a brief summary and expand to reveal additional content. Use them to progressively disclose information, group related FAQs, or hide advanced options.
+
+**Documentation:** https://webawesome.com/docs/components/details
+
+**Slots:**
+
+- `(default)`: The details' main content.
+- `summary`: The details' summary. Alternatively, you can use the `summary` attribute.
+- `expand-icon`: Optional expand icon to use instead of the default. Works best with `<wa-icon>`.
+- `collapse-icon`: Optional collapse icon to use instead of the default. Works best with `<wa-icon>`.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `open`: Indicates whether or not the details is open. You can toggle this attribute to show and hide the details, or you can use the `show()` and `hide()` methods and this attribute will reflect the details' open state. (Type: `boolean`, Default: `false`)
+- `summary`: The summary to show in the header. If you need to display HTML, use the `summary` slot instead. (Type: `string`)
+- `name`: Groups related details elements. When one opens, others with the same name will close. (Type: `string`)
+- `disabled`: Disables the details so it can't be toggled. (Type: `boolean`, Default: `false`)
+- `appearance`: The element's visual appearance. (Type: `'filled' | 'outlined' | 'filled-outlined' | 'plain'`, Default: `'outlined'`)
+- `iconPlacement` (attribute: `icon-placement`): The location of the expand/collapse icon. (Type: `'start' | 'end'`, Default: `'end'`)
+
+**Methods:**
+
+- `show()`: Shows the details.
+- `hide()`: Hides the details
+
+**Events:**
+
+- `wa-show`: Emitted when the details opens.
+- `wa-after-show`: Emitted after the details opens and all animations are complete.
+- `wa-hide`: Emitted when the details closes.
+- `wa-after-hide`: Emitted after the details closes and all animations are complete.
+
+**CSS Custom Properties:**
+
+- `--spacing`: The amount of space around and between the details' content. Expects a single value.
+- `--show-duration`: The show duration to use when applying built-in animation classes. (Default: `200ms`)
+- `--hide-duration`: The hide duration to use when applying built-in animation classes. (Default: `200ms`)
+
+**CSS Parts:**
+
+- `base`: The inner `<details>` element used to render the component. Styles you apply to the component are automatically applied to this part, so you usually don't need to deal with it unless you need to set the `display` property.
+- `header`: The header that wraps both the summary and the expand/collapse icon.
+- `summary`: The container that wraps the summary.
+- `icon`: The container that wraps the expand/collapse icons.
+- `content`: The details content.
+
+**CSS States:**
+
+- `animating`: Applied when the details is animating expand/collapse.
+
+#### `<wa-dialog>`
+
+**Description:** Dialogs appear above the page and require the user's immediate attention. Use them for confirmations, forms, or focused tasks that interrupt the main flow.
+
+**Documentation:** https://webawesome.com/docs/components/dialog
+
+**Slots:**
+
+- `(default)`: The dialog's main content.
+- `label`: The dialog's label. Alternatively, you can use the `label` attribute.
+- `header-actions`: Optional actions to add to the header. Works best with `<wa-button>`.
+- `footer`: The dialog's footer, usually one or more buttons representing various options.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `open`: Indicates whether or not the dialog is open. Toggle this attribute to show and hide the dialog. (Type: `boolean`, Default: `false`)
+- `label`: The dialog's label as displayed in the header. You should always include a relevant label, as it is required for proper accessibility. If you need to display HTML, use the `label` slot instead. (Type: `string`, Default: `''`)
+- `withoutHeader` (attribute: `without-header`): Disables the header. This will also remove the default close button. (Type: `boolean`, Default: `false`)
+- `lightDismiss` (attribute: `light-dismiss`): When enabled, the dialog will be closed when the user clicks outside of it. (Type: `boolean`, Default: `false`)
+- `withFooter` (attribute: `with-footer`): Only required for SSR. Set to `true` if you're slotting in a `footer` element so the server-rendered markup includes the footer before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+
+**Events:**
+
+- `wa-show`: Emitted when the dialog opens.
+- `wa-after-show`: Emitted after the dialog opens and all animations are complete.
+- `wa-hide`: Emitted when the dialog is requested to close. Calling `event.preventDefault()` will prevent the dialog from closing. You can inspect `event.detail.source` to see which element caused the dialog to close. If the source is the dialog element itself, the user has pressed [[Escape]] or the dialog has been closed programmatically. Avoid using this unless closing the dialog will result in destructive behavior such as data loss.
+- `wa-after-hide`: Emitted after the dialog closes and all animations are complete.
+
+**CSS Custom Properties:**
+
+- `--spacing`: The amount of space around and between the dialog's content.
+- `--width`: The preferred width of the dialog. Note that the dialog will shrink to accommodate smaller screens.
+- `--backdrop-filter`: A filter to apply to the backdrop behind the dialog. (Default: `none`)
+- `--show-duration`: The animation duration when showing the dialog. (Default: `200ms`)
+- `--hide-duration`: The animation duration when hiding the dialog. (Default: `200ms`)
+
+**CSS Parts:**
+
+- `dialog`: The dialog's internal `<dialog>` element.
+- `header`: The dialog's header. This element wraps the title and header actions.
+- `header-actions`: Optional actions to add to the header. Works best with `<wa-button>`.
+- `title`: The dialog's title.
+- `close-button`: The close button, a `<wa-button>`.
+- `close-button__base`: The close button's exported `base` part.
+- `body`: The dialog's body.
+- `footer`: The dialog's footer.
+
+#### `<wa-divider>`
+
+**Description:** Dividers visually separate or group adjacent elements with a horizontal or vertical line. Use them to establish rhythm and hierarchy within menus, toolbars, and layouts.
+
+**Documentation:** https://webawesome.com/docs/components/divider
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `orientation`: Sets the divider's orientation. (Type: `'horizontal' | 'vertical'`, Default: `'horizontal'`)
+
+**CSS Custom Properties:**
+
+- `--color`: The color of the divider.
+- `--width`: The width of the divider.
+- `--spacing`: The spacing of the divider.
+
+#### `<wa-doughnut-chart>`
+
+**Description:** Doughnut charts show proportional data as slices of a ring with a hollow center. They offer a cleaner look than pie charts and work well in dashboards where the center space can provide additional context.
+
+**Documentation:** https://webawesome.com/docs/components/doughnut-chart
+
+**Slots:**
+
+- `(default)`: An optional `<script type="application/json">` element containing the Chart.js configuration object.
+
+**Properties:**
+
+- `type`: The type of chart to render. Valid types include `bar`, `line`, `pie`, `doughnut`, `polarArea`, `radar`, `scatter`, and `bubble`. (Type: `ChartType`, Default: `'doughnut'`)
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles]`)
+- `label`: A label for the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `description`: A description of the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `xLabel`: A label for the x-axis. (Type: `string | null`, Default: `null`)
+- `yLabel`: A label for the y-axis. (Type: `string | null`, Default: `null`)
+- `legendPosition` (attribute: `legend-position`): The position of the legend relative to the chart. (Type: `LayoutPosition | 'start' | 'end'`, Default: `'top'`)
+- `stacked`: Stacks datasets on top of each other along the value axis. (Type: `boolean`, Default: `false`)
+- `indexAxis` (attribute: `index-axis`): The base axis of the dataset. 'x' for vertical bars and 'y' for horizontal bars. (Type: `'x' | 'y'`, Default: `'x'`)
+- `grid`: Which axes to show grid lines on. (Type: `'x' | 'y' | 'both' | 'none'`, Default: `'both'`)
+- `min`: The minimum value for the value axis. (Type: `number | null`, Default: `null`)
+- `max`: The maximum value for the value axis. (Type: `number | null`, Default: `null`)
+- `withoutAnimation` (attribute: `without-animation`): Disables chart animations (Type: `boolean`, Default: `false`)
+- `withoutLegend` (attribute: `without-legend`): Hides the legend (Type: `boolean`, Default: `false`)
+- `withoutTooltip` (attribute: `without-tooltip`): Hides tooltips over data points (Type: `boolean`, Default: `false`)
+- `config`: The Chart.js configuration object. Setting this property will automatically re-render the chart. (Type: `ChartJS['config']`)
+- `plugins`: Additional Chart.js plugins to register for this chart instance. (Type: `array`, Default: `[]`)
+
+**CSS Custom Properties:**
+
+- `--fill-color-1`: Fill color for the first dataset. (Default: `color-mix(in srgb, var(--wa-color-blue-60) 40%, transparent)`)
+- `--fill-color-2`: Fill color for the second dataset. (Default: `color-mix(in srgb, var(--wa-color-pink-60) 40%, transparent)`)
+- `--fill-color-3`: Fill color for the third dataset. (Default: `color-mix(in srgb, var(--wa-color-green-60) 40%, transparent)`)
+- `--fill-color-4`: Fill color for the fourth dataset. (Default: `color-mix(in srgb, var(--wa-color-yellow-60) 40%, transparent)`)
+- `--fill-color-5`: Fill color for the fifth dataset. (Default: `color-mix(in srgb, var(--wa-color-purple-60) 40%, transparent)`)
+- `--fill-color-6`: Fill color for the sixth dataset. (Default: `color-mix(in srgb, var(--wa-color-orange-60) 40%, transparent)`)
+- `--border-color-1`: Border color for the first dataset. (Default: `var(--wa-color-blue-60)`)
+- `--border-color-2`: Border color for the second dataset. (Default: `var(--wa-color-pink-60)`)
+- `--border-color-3`: Border color for the third dataset. (Default: `var(--wa-color-green-60)`)
+- `--border-color-4`: Border color for the fourth dataset. (Default: `var(--wa-color-yellow-60)`)
+- `--border-color-5`: Border color for the fifth dataset. (Default: `var(--wa-color-purple-60)`)
+- `--border-color-6`: Border color for the sixth dataset. (Default: `var(--wa-color-orange-60)`)
+- `--grid-color`: Color of the chart grid lines and axis borders. (Default: `var(--wa-color-neutral-border-quiet)`)
+- `--border-width`: Border width for bars and arcs. (Default: `var(--wa-border-width-s)`)
+- `--border-radius`: Border radius for bar charts. (Default: `var(--wa-border-radius-s)`)
+- `--grid-border-width`: Border width for chart grid lines and axis borders. (Default: `var(--wa-border-width-s)`)
+- `--line-border-width`: Border width for line and radar charts. (Default: `var(--wa-border-width-m)`)
+- `--point-radius`: Radius of data point dots. (Default: `var(--wa-border-width-m)`)
+
+#### `<wa-drawer>`
+
+**Description:** Drawers slide in from the edge of a container to expose additional options and information without navigating away. Useful for navigation menus, filters, and secondary content.
+
+**Documentation:** https://webawesome.com/docs/components/drawer
+
+**Slots:**
+
+- `(default)`: The drawer's main content.
+- `label`: The drawer's label. Alternatively, you can use the `label` attribute.
+- `header-actions`: Optional actions to add to the header. Works best with `<wa-button>`.
+- `footer`: The drawer's footer, usually one or more buttons representing various options.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `open`: Indicates whether or not the drawer is open. Toggle this attribute to show and hide the drawer. (Type: `boolean`, Default: `false`)
+- `label`: The drawer's label as displayed in the header. You should always include a relevant label, as it is required for proper accessibility. If you need to display HTML, use the `label` slot instead. (Type: `string`, Default: `''`)
+- `placement`: The direction from which the drawer will open. (Type: `'top' | 'end' | 'bottom' | 'start'`, Default: `'end'`)
+- `withoutHeader` (attribute: `without-header`): Disables the header. This will also remove the default close button. (Type: `boolean`, Default: `false`)
+- `lightDismiss` (attribute: `light-dismiss`): When enabled, the drawer will be closed when the user clicks outside of it. (Type: `boolean`, Default: `true`)
+- `withFooter` (attribute: `with-footer`): Only required for SSR. Set to `true` if you're slotting in a `footer` element so the server-rendered markup includes the footer before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `modal`: Exposes the internal modal utility that controls focus trapping. To temporarily disable focus trapping and allow third-party modals spawned from an active Shoelace modal, call `modal.activateExternal()` when the third-party modal opens. Upon closing, call `modal.deactivateExternal()` to restore Shoelace's focus trapping.
+
+**Events:**
+
+- `wa-show`: Emitted when the drawer opens.
+- `wa-after-show`: Emitted after the drawer opens and all animations are complete.
+- `wa-hide`: Emitted when the drawer is requesting to close. Calling `event.preventDefault()` will prevent the drawer from closing. You can inspect `event.detail.source` to see which element caused the drawer to close. If the source is the drawer element itself, the user has pressed [[Escape]] or the drawer has been closed programmatically. Avoid using this unless closing the drawer will result in destructive behavior such as data loss.
+- `wa-after-hide`: Emitted after the drawer closes and all animations are complete.
+
+**CSS Custom Properties:**
+
+- `--spacing`: The amount of space around and between the drawer's content.
+- `--size`: The preferred size of the drawer. This will be applied to the drawer's width or height depending on its `placement`. Note that the drawer will shrink to accommodate smaller screens.
+- `--backdrop-filter`: A filter to apply to the backdrop behind the drawer. (Default: `none`)
+- `--show-duration`: The animation duration when showing the drawer. (Default: `200ms`)
+- `--hide-duration`: The animation duration when hiding the drawer. (Default: `200ms`)
+
+**CSS Parts:**
+
+- `dialog`: The drawer's internal `<dialog>` element.
+- `header`: The drawer's header. This element wraps the title and header actions.
+- `header-actions`: Optional actions to add to the header. Works best with `<wa-button>`.
+- `title`: The drawer's title.
+- `close-button`: The close button, a `<wa-button>`.
+- `close-button__base`: The close button's exported `base` part.
+- `body`: The drawer's body.
+- `footer`: The drawer's footer.
+
+#### `<wa-dropdown>`
+
+**Description:** Dropdowns display a list of options triggered by a button or other element. They support keyboard navigation, submenus, and checkable items for building menus and context actions.
+
+**Documentation:** https://webawesome.com/docs/components/dropdown
+
+**Slots:**
+
+- `(default)`: The dropdown's items, typically `<wa-dropdown-item>` elements.
+- `trigger`: The element that triggers the dropdown, such as a `<wa-button>` or `<button>`.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[sizeStyles, styles]`)
+- `open`: Opens or closes the dropdown. (Type: `boolean`, Default: `false`)
+- `size`: The dropdown's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `placement`: The placement of the dropdown menu in reference to the trigger. The menu will shift to a more optimal location if the preferred placement doesn't have enough room. (Type: `| 'top'     | 'top-start'     | 'top-end'     | 'bottom'     | 'bottom-start'     | 'bottom-end'     | 'right'     | 'right-start'     | 'right-end'     | 'left'     | 'left-start'     | 'left-end'`, Default: `'bottom-start'`)
+- `distance`: The distance of the dropdown menu from its trigger. (Type: `number`, Default: `0`)
+- `skidding`: The offset of the dropdown menu along its trigger. (Type: `number`, Default: `0`)
+
+**Events:**
+
+- `wa-show`: Emitted when the dropdown is about to show.
+- `wa-after-show`: Emitted after the dropdown has been shown.
+- `wa-hide`: Emitted when the dropdown is about to hide.
+- `wa-after-hide`: Emitted after the dropdown has been hidden.
+- `wa-select`: Emitted when an item in the dropdown is selected.
+
+**CSS Custom Properties:**
+
+- `--show-duration`: The duration of the show animation.
+- `--hide-duration`: The duration of the hide animation.
+
+**CSS Parts:**
+
+- `base`: The component's host element.
+- `menu`: The dropdown menu container.
+
+#### `<wa-dropdown-item>`
+
+**Description:** Dropdown items represent selectable entries within a dropdown menu, including standard actions, checkable items, and submenu triggers.
+
+**Documentation:** https://webawesome.com/docs/components/dropdown-item
+
+**Slots:**
+
+- `(default)`: The dropdown item's label.
+- `icon`: An optional icon to display before the label.
+- `details`: Additional content or details to display after the label.
+- `submenu`: Submenu items, typically `<wa-dropdown-item>` elements, to create a nested menu.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `variant`: The type of menu item to render. (Type: `'danger' | 'default'`, Default: `'default'`)
+- `value`: An optional value for the menu item. This is useful for determining which item was selected when listening to the dropdown's `wa-select` event. (Type: `string`)
+- `type`: Set to `checkbox` to make the item a checkbox. (Type: `'normal' | 'checkbox'`, Default: `'normal'`)
+- `checked`: Set to true to check the dropdown item. Only valid when `type` is `checkbox`. (Type: `boolean`, Default: `false`)
+- `disabled`: Disables the dropdown item. (Type: `boolean`, Default: `false`)
+- `submenuOpen`: Whether the submenu is currently open. (Type: `boolean`, Default: `false`)
+
+**Methods:**
+
+- `openSubmenu()`: Opens the submenu.
+- `closeSubmenu()`: Closes the submenu.
+
+**Events:**
+
+- `blur`: Emitted when the dropdown item loses focus.
+- `focus`: Emitted when the dropdown item gains focus.
+
+**CSS Parts:**
+
+- `checkmark`: The checkmark icon (a `<wa-icon>` element) when the item is a checkbox.
+- `icon`: The container for the icon slot.
+- `label`: The container for the label slot.
+- `details`: The container for the details slot.
+- `submenu-icon`: The submenu indicator icon (a `<wa-icon>` element).
+- `submenu`: The submenu container.
+
+#### `<wa-file-input>`
+
+**Description:** File inputs allow users to select files from their device.
+
+**Documentation:** https://webawesome.com/docs/components/file-input
+
+**Slots:**
+
+- `label`: The file input's label. Alternatively, you can use the `label` attribute.
+- `hint`: Text that describes how to use the file input. Alternatively, you can use the `hint` attribute.
+- `dropzone`: Custom content to show in the dropzone.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[sizeStyles, formControlStyles, styles]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `files`: The selected files. (Type: `File[]`, Default: `[]`)
+- `dragging`: Whether files are being dragged over the dropzone. (Type: `boolean`, Default: `false`)
+- `size`: The file input's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `label`: The file input's label. If you need to display HTML, use the `label` slot instead. (Type: `string`, Default: `''`)
+- `hint`: The file input's hint. If you need to display HTML, use the `hint` slot instead. (Type: `string`, Default: `''`)
+- `multiple`: Allows more than one file to be selected. (Type: `boolean`, Default: `false`)
+- `accept`: A comma-separated list of acceptable file types. Must be a list of [unique file type specifiers](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/file#unique_file_type_specifiers). (Type: `string`, Default: `''`)
+- `required`: Makes the file input a required field. (Type: `boolean`, Default: `false`)
+- `withLabel` (attribute: `with-label`): Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup includes the label before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withHint` (attribute: `with-hint`): Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup includes the hint before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `fileCount`: The number of selected files. Used for validation. (Type: `number`)
+- `name`: The name of the input, submitted as a name/value pair with form data. (Type: `string | null`, Default: `null`)
+- `disabled`: Disables the form control. (Type: `boolean`, Default: `false`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+- `validationTarget`: Override this to change where constraint validation popups are anchored. (Type: `undefined | HTMLElement`)
+
+**Methods:**
+
+- `focus(options: FocusOptions)`: Sets focus on the file input.
+- `blur()`: Removes focus from the file input.
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `input`: Emitted when file selection changes.
+- `change`: Emitted when files are added or removed.
+- `focus`: Emitted when the dropzone gains focus.
+- `blur`: Emitted when the dropzone loses focus.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Parts:**
+
+- `label`: The label element.
+- `hint`: The hint element.
+- `base`: The main component wrapper.
+- `dropzone`: The drag-and-drop area.
+- `dropzone-icon`: The upload icon in the dropzone.
+- `dropzone-text`: The instruction text in the dropzone.
+- `file-list`: The container for selected files.
+- `file`: Individual file item container.
+- `file-thumbnail`: The thumbnail/icon container for a file.
+- `file-image`: The image element for image thumbnails.
+- `file-icon`: The icon for non-image files.
+- `file-details`: Container for file name and size.
+- `file-name`: The file name text.
+- `file-size`: The file size text.
+- `remove-button`: The remove button for each file.
+
+**CSS States:**
+
+- `blank`: No files selected.
+- `dragging`: Files being dragged over dropzone.
+
+#### `<wa-format-bytes>`
+
+**Description:** Formats a number of bytes as a human-readable string with the appropriate unit, such as kB, MB, or GB. Supports both byte and bit units with configurable locale.
+
+**Documentation:** https://webawesome.com/docs/components/format-bytes
+
+**Properties:**
+
+- `value`: The number to format in bytes. (Type: `number`, Default: `0`)
+- `unit`: The type of unit to display. (Type: `'byte' | 'bit'`, Default: `'byte'`)
+- `display`: Determines how to display the result, e.g. "100 bytes", "100 b", or "100b". (Type: `'long' | 'short' | 'narrow'`, Default: `'short'`)
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`)
+
+#### `<wa-format-date>`
+
+**Description:** Formats a date or time for display using the specified locale and options. Powered by the Intl.DateTimeFormat API for consistent, localized output.
+
+**Documentation:** https://webawesome.com/docs/components/format-date
+
+**Properties:**
+
+- `date`: The date/time to format. If not set, the current date and time will be used. When passing a string, it's strongly recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert a date to this format in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString). (Type: `Date | string`, Default: `new Date()`)
+- `weekday`: The format for displaying the weekday. (Type: `'narrow' | 'short' | 'long'`)
+- `era`: The format for displaying the era. (Type: `'narrow' | 'short' | 'long'`)
+- `year`: The format for displaying the year. (Type: `'numeric' | '2-digit'`)
+- `month`: The format for displaying the month. (Type: `'numeric' | '2-digit' | 'narrow' | 'short' | 'long'`)
+- `day`: The format for displaying the day. (Type: `'numeric' | '2-digit'`)
+- `hour`: The format for displaying the hour. (Type: `'numeric' | '2-digit'`)
+- `minute`: The format for displaying the minute. (Type: `'numeric' | '2-digit'`)
+- `second`: The format for displaying the second. (Type: `'numeric' | '2-digit'`)
+- `timeZoneName` (attribute: `time-zone-name`): The format for displaying the time. (Type: `'short' | 'long'`)
+- `timeZone` (attribute: `time-zone`): The time zone to express the time in. (Type: `string`)
+- `hourFormat` (attribute: `hour-format`): The format for displaying the hour. (Type: `'auto' | '12' | '24'`, Default: `'auto'`)
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`)
+
+#### `<wa-format-number>`
+
+**Description:** Formats a number for display using the specified locale and options, including currency, percent, and unit styles. Powered by the Intl.NumberFormat API.
+
+**Documentation:** https://webawesome.com/docs/components/format-number
+
+**Properties:**
+
+- `value`: The number to format. (Type: `number`, Default: `0`)
+- `type`: The formatting style to use. (Type: `'currency' | 'decimal' | 'percent'`, Default: `'decimal'`)
+- `withoutGrouping` (attribute: `without-grouping`): Turns off grouping separators. (Type: `boolean`, Default: `false`)
+- `currency`: The [ISO 4217](https://en.wikipedia.org/wiki/ISO_4217) currency code to use when formatting. (Type: `string`, Default: `'USD'`)
+- `currencyDisplay` (attribute: `currency-display`): How to display the currency. (Type: `'symbol' | 'narrowSymbol' | 'code' | 'name'`, Default: `'symbol'`)
+- `minimumIntegerDigits` (attribute: `minimum-integer-digits`): The minimum number of integer digits to use. Possible values are 1-21. (Type: `number`)
+- `minimumFractionDigits` (attribute: `minimum-fraction-digits`): The minimum number of fraction digits to use. Possible values are 0-100. (Type: `number`)
+- `maximumFractionDigits` (attribute: `maximum-fraction-digits`): The maximum number of fraction digits to use. Possible values are 0-100. (Type: `number`)
+- `minimumSignificantDigits` (attribute: `minimum-significant-digits`): The minimum number of significant digits to use. Possible values are 1-21. (Type: `number`)
+- `maximumSignificantDigits` (attribute: `maximum-significant-digits`): The maximum number of significant digits to use,. Possible values are 1-21. (Type: `number`)
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`)
+
+#### `<wa-icon>`
+
+**Description:** Icons are scalable vector symbols that represent actions, content, or status throughout your application. They support Font Awesome and custom icon libraries with animation presets.
+
+**Documentation:** https://webawesome.com/docs/components/icon
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `name`: The name of the icon to draw. Available names depend on the icon library being used. (Type: `string | undefined`)
+- `family`: The family of icons to choose from. For Font Awesome Free, valid options include `classic` and `brands`. For Font Awesome Pro subscribers, valid options include, `classic`, `sharp`, `duotone`, `sharp-duotone`, and `brands`. A valid kit code must be present to show pro icons via CDN. You can set `<html data-fa-kit-code="...">` to provide one. (Type: `string`)
+- `variant`: The name of the icon's variant. For Font Awesome, valid options include `thin`, `light`, `regular`, and `solid` for the `classic` and `sharp` families. Some variants require a Font Awesome Pro subscription. Custom icon libraries may or may not use this property. (Type: `string`)
+- `autoWidth` (attribute: `auto-width`): Sets the width of the icon to match the cropped SVG viewBox. This operates like the Font `fa-width-auto` class. (Type: `boolean`, Default: `false`)
+- `swapOpacity` (attribute: `swap-opacity`): Swaps the opacity of duotone icons. (Type: `boolean`, Default: `false`)
+- `src`: An external URL of an SVG file. Be sure you trust the content you are including, as it will be executed as code and can result in XSS attacks. (Type: `string | undefined`)
+- `label`: An alternate description to use for assistive devices. If omitted, the icon will be considered presentational and ignored by assistive devices. (Type: `string`, Default: `''`)
+- `library`: The name of a registered custom icon library. (Type: `string`, Default: `'default'`)
+- `rotate`: Sets the rotation degree of the icon (Type: `number`, Default: `0`)
+- `flip`: Sets the flip direction of the icon along the 'x' (horizontal), 'y' (vertical), or 'both' axes. (Type: `'x' | 'y' | 'both' | undefined`)
+- `animation`: Sets the animation for the icon (Type: `IconAnimation | undefined`)
+
+**Events:**
+
+- `wa-load`: Emitted when the icon has loaded. When using `spriteSheet: true` this will not emit.
+- `wa-error`: Emitted when the icon fails to load due to an error. When using `spriteSheet: true` this will not emit.
+
+**CSS Custom Properties:**
+
+- `--animation-delay`: Sets when the animation will start. (Default: `0`)
+- `--animation-direction`: Defines whether or not the animation should play in reverse on alternate cycles. (Default: `normal`)
+- `--animation-duration`: Defines the length of time that an animation takes to complete one cycle. (Default: `1s`)
+- `--animation-iteration-count`: Defines the number of times an animation cycle is played. (Default: `infinite`)
+- `--animation-timing`: Describes how the animation will progress over one cycle of its duration.
+- `--beat-fade-opacity`: Set lowest opacity value an icon with `beat-fade` animation will fade to and from.
+- `--beat-fade-scale`: Set max value that an icon with `beat-fade` animation will scale.
+- `--beat-scale`: Set max value that an icon with `beat` animation will scale.
+- `--bounce-height`: Set the max height an icon with `bounce` animation will jump to when bouncing.
+- `--bounce-jump-scale-x`: Set the icon’s horizontal distortion (“squish”) at the top of the jump.
+- `--bounce-jump-scale-y`: Set the icon’s vertical distortion (“squish”) at the top of the jump.
+- `--bounce-land-scale-x`: Set the icon’s horizontal distortion (“squish”) when landing after the jump.
+- `--bounce-land-scale-y`: Set the icon’s vertical distortion (“squish”) when landing after the jump.
+- `--bounce-rebound`: Set the amount of rebound an icon with `bounce` animation has when landing after the jump.
+- `--bounce-start-scale-x`: Set the icon’s horizontal distortion (“squish”) when starting to bounce.
+- `--bounce-start-scale-y`: Set the icon’s vertical distortion (“squish”) when starting to bounce.
+- `--fade-opacity`: Set lowest opacity value an icon with `fade` animation will fade to and from.
+- `--flip-angle`: Set rotation angle of flip for an icon with `flip` animation. A positive angle denotes a clockwise rotation, a negative angle a counter-clockwise one.
+- `--flip-x`: Set x-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` animation.
+- `--flip-y`: Set y-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` animation.
+- `--flip-z`: Set z-coordinate of the vector denoting the axis of rotation (between 0 and 1) for an icon with `flip` animation.
+- `--primary-color`: Sets a duotone icon's primary color. (Default: `currentColor`)
+- `--primary-opacity`: Sets a duotone icon's primary opacity. (Default: `1`)
+- `--secondary-color`: Sets a duotone icon's secondary color. (Default: `currentColor`)
+- `--secondary-opacity`: Sets a duotone icon's secondary opacity. (Default: `0.4`)
+
+**CSS Parts:**
+
+- `svg`: The internal SVG element.
+- `use`: The `<use>` element generated when using `spriteSheet: true`
+
+#### `<wa-include>`
+
+**Description:** Fetches an external HTML file and embeds its contents inline on the page. Useful for reusing shared markup like headers, footers, and partials across multiple pages.
+
+**Documentation:** https://webawesome.com/docs/components/include
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `src`: The location of the HTML file to include. Be sure you trust the content you are including as it will be executed as code and can result in XSS attacks. (Type: `string`)
+- `mode`: The fetch mode to use. (Type: `'cors' | 'no-cors' | 'same-origin'`, Default: `'cors'`)
+- `allowScripts` (attribute: `allow-scripts`): Allows included scripts to be executed. Be sure you trust the content you are including as it will be executed as code and can result in XSS attacks. (Type: `boolean`, Default: `false`)
+
+**Events:**
+
+- `wa-load`: Emitted when the included file is loaded.
+- `wa-include-error`: Emitted when the included file fails to load due to an error.
+
+#### `<wa-input>`
+
+**Description:** Inputs collect single-line data from the user, such as text, numbers, email addresses, and passwords. They support labels, hints, validation, and prefix or suffix slots.
+
+**Documentation:** https://webawesome.com/docs/components/input
+
+**Slots:**
+
+- `label`: The input's label. Alternatively, you can use the `label` attribute.
+- `start`: An element, such as `<wa-icon>`, placed at the start of the input control.
+- `end`: An element, such as `<wa-icon>`, placed at the end of the input control.
+- `clear-icon`: An icon to use in lieu of the default clear icon.
+- `show-password-icon`: An icon to use in lieu of the default show password icon.
+- `hide-password-icon`: An icon to use in lieu of the default hide password icon.
+- `hint`: Text that describes how to use the input. Alternatively, you can use the `hint` attribute.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[sizeStyles, formControlStyles, styles]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `type`: The type of input. Works the same as a native `<input>` element, but only a subset of types are supported. Defaults to `text`. (Type: `| 'date'     | 'datetime-local'     | 'email'     | 'number'     | 'password'     | 'search'     | 'tel'     | 'text'     | 'time'     | 'url'`, Default: `'text'`)
+- `value`: The current value of the input, submitted as a name/value pair with form data.
+- `defaultValue` (attribute: `value`): The default value of the form control. Primarily used for resetting the form control. (Type: `string | null`)
+- `size`: The input's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `appearance`: The input's visual appearance. (Type: `'filled' | 'outlined' | 'filled-outlined'`, Default: `'outlined'`)
+- `pill`: Draws a pill-style input with rounded edges. (Type: `boolean`, Default: `false`)
+- `label`: The input's label. If you need to display HTML, use the `label` slot instead. (Type: `string`, Default: `''`)
+- `hint`: The input's hint. If you need to display HTML, use the `hint` slot instead. (Type: `string`, Default: `''`)
+- `withClear` (attribute: `with-clear`): Adds a clear button when the input is not empty. (Type: `boolean`, Default: `false`)
+- `placeholder`: Placeholder text to show as a hint when the input is empty. (Type: `string`, Default: `''`)
+- `readonly`: Makes the input readonly. (Type: `boolean`, Default: `false`)
+- `passwordToggle` (attribute: `password-toggle`): Adds a button to toggle the password's visibility. Only applies to password types. (Type: `boolean`, Default: `false`)
+- `passwordVisible` (attribute: `password-visible`): Determines whether or not the password is currently visible. Only applies to password input types. (Type: `boolean`, Default: `false`)
+- `withoutSpinButtons` (attribute: `without-spin-buttons`): Hides the browser's built-in increment/decrement spin buttons for number inputs. (Type: `boolean`, Default: `false`)
+- `required`: Makes the input a required field. (Type: `boolean`, Default: `false`)
+- `pattern`: A regular expression pattern to validate input against. (Type: `string`)
+- `minlength`: The minimum length of input that will be considered valid. (Type: `number`)
+- `maxlength`: The maximum length of input that will be considered valid. (Type: `number`)
+- `min`: The input's minimum value. Only applies to date and number input types. (Type: `number | string`)
+- `max`: The input's maximum value. Only applies to date and number input types. (Type: `number | string`)
+- `step`: Specifies the granularity that the value must adhere to, or the special value `any` which means no stepping is implied, allowing any numeric value. Only applies to date and number input types. (Type: `number | 'any'`)
+- `autocapitalize`: Controls whether and how text input is automatically capitalized as it is entered by the user. (Type: `'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters'`)
+- `autocorrect`: Indicates whether the browser's autocorrect feature is on or off. When set as an attribute, use `"off"` or `"on"`. When set as a property, use `true` or `false`. (Type: `boolean`)
+- `autocomplete`: Specifies what permission the browser has to provide assistance in filling out form field values. Refer to [this page on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) for available values. (Type: `string`)
+- `autofocus`: Indicates that the input should receive focus on page load. (Type: `boolean`)
+- `enterkeyhint`: Used to customize the label or icon of the Enter key on virtual keyboards. (Type: `'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send'`)
+- `spellcheck`: Enables spell checking on the input. (Type: `boolean`, Default: `true`)
+- `inputmode`: Tells the browser what type of data will be entered by the user, allowing it to display the appropriate virtual keyboard on supportive devices. (Type: `'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url'`)
+- `withLabel` (attribute: `with-label`): Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup includes the label before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withHint` (attribute: `with-hint`): Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup includes the hint before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `name`: The name of the input, submitted as a name/value pair with form data. (Type: `string | null`, Default: `null`)
+- `disabled`: Disables the form control. (Type: `boolean`, Default: `false`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+- `validationTarget`: Override this to change where constraint validation popups are anchored. (Type: `undefined | HTMLElement`)
+
+**Methods:**
+
+- `focus(options: FocusOptions)`: Sets focus on the input.
+- `blur()`: Removes focus from the input.
+- `select()`: Selects all the text in the input.
+- `setSelectionRange(selectionStart: number, selectionEnd: number, selectionDirection: 'forward' | 'backward' | 'none')`: Sets the start and end positions of the text selection (0-based).
+- `setRangeText(replacement: string, start: number, end: number, selectMode: 'select' | 'start' | 'end' | 'preserve')`: Replaces a range of text with a new string.
+- `showPicker()`: Displays the browser picker for an input element (only works if the browser supports it for the input type).
+- `stepUp()`: Increments the value of a numeric input type by the value of the step attribute.
+- `stepDown()`: Decrements the value of a numeric input type by the value of the step attribute.
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `input`: Emitted when the control receives input.
+- `change`: Emitted when an alteration to the control's value is committed by the user.
+- `blur`: Emitted when the control loses focus.
+- `focus`: Emitted when the control gains focus.
+- `wa-clear`: Emitted when the clear button is activated.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Parts:**
+
+- `label`: The label
+- `hint`: The hint's wrapper.
+- `base`: The wrapper being rendered as an input
+- `input`: The internal `<input>` control.
+- `start`: The container that wraps the `start` slot.
+- `clear-button`: The clear button.
+- `password-toggle-button`: The password toggle button.
+- `end`: The container that wraps the `end` slot.
+
+**CSS States:**
+
+- `blank`: The input is empty.
+
+#### `<wa-intersection-observer>`
+
+**Description:** Tracks immediate child elements and fires events as they move in and out of view. Useful for lazy loading, scroll-triggered animations, and viewport-aware interactions.
+
+**Documentation:** https://webawesome.com/docs/components/intersection-observer
+
+**Slots:**
+
+- `(default)`: Elements to track. Only immediate children of the host are monitored.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `root`: Element ID to define the viewport boundaries for tracked targets. (Type: `string | null`, Default: `null`)
+- `rootMargin` (attribute: `root-margin`): Offset space around the root boundary. Accepts values like CSS margin syntax. (Type: `string`, Default: `'0px'`)
+- `threshold`: One or more space-separated values representing visibility percentages that trigger the observer callback. (Type: `string`, Default: `'0'`)
+- `intersectClass` (attribute: `intersect-class`): CSS class applied to elements during intersection. Automatically removed when elements leave the viewport, enabling pure CSS styling based on visibility state. (Type: `string`, Default: `''`)
+- `once`: If enabled, observation ceases after initial intersection. (Type: `boolean`, Default: `false`)
+- `disabled`: Deactivates the intersection observer functionality. (Type: `boolean`, Default: `false`)
+
+**Events:**
+
+- `wa-intersect`: Fired when a tracked element begins or ceases intersecting.
+
+#### `<wa-line-chart>`
+
+**Description:** Line charts show trends over time by connecting data points with line segments. Use them when the x-axis represents a sequential dimension and you want to emphasize the shape and direction of the data.
+
+**Documentation:** https://webawesome.com/docs/components/line-chart
+
+**Slots:**
+
+- `(default)`: An optional `<script type="application/json">` element containing the Chart.js configuration object.
+
+**Properties:**
+
+- `type`: The type of chart to render. Valid types include `bar`, `line`, `pie`, `doughnut`, `polarArea`, `radar`, `scatter`, and `bubble`. (Type: `ChartType`, Default: `'line'`)
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles]`)
+- `label`: A label for the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `description`: A description of the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `xLabel`: A label for the x-axis. (Type: `string | null`, Default: `null`)
+- `yLabel`: A label for the y-axis. (Type: `string | null`, Default: `null`)
+- `legendPosition` (attribute: `legend-position`): The position of the legend relative to the chart. (Type: `LayoutPosition | 'start' | 'end'`, Default: `'top'`)
+- `stacked`: Stacks datasets on top of each other along the value axis. (Type: `boolean`, Default: `false`)
+- `indexAxis` (attribute: `index-axis`): The base axis of the dataset. 'x' for vertical bars and 'y' for horizontal bars. (Type: `'x' | 'y'`, Default: `'x'`)
+- `grid`: Which axes to show grid lines on. (Type: `'x' | 'y' | 'both' | 'none'`, Default: `'both'`)
+- `min`: The minimum value for the value axis. (Type: `number | null`, Default: `null`)
+- `max`: The maximum value for the value axis. (Type: `number | null`, Default: `null`)
+- `withoutAnimation` (attribute: `without-animation`): Disables chart animations (Type: `boolean`, Default: `false`)
+- `withoutLegend` (attribute: `without-legend`): Hides the legend (Type: `boolean`, Default: `false`)
+- `withoutTooltip` (attribute: `without-tooltip`): Hides tooltips over data points (Type: `boolean`, Default: `false`)
+- `config`: The Chart.js configuration object. Setting this property will automatically re-render the chart. (Type: `ChartJS['config']`)
+- `plugins`: Additional Chart.js plugins to register for this chart instance. (Type: `array`, Default: `[]`)
+
+**CSS Custom Properties:**
+
+- `--fill-color-1`: Fill color for the first dataset. (Default: `color-mix(in srgb, var(--wa-color-blue-60) 40%, transparent)`)
+- `--fill-color-2`: Fill color for the second dataset. (Default: `color-mix(in srgb, var(--wa-color-pink-60) 40%, transparent)`)
+- `--fill-color-3`: Fill color for the third dataset. (Default: `color-mix(in srgb, var(--wa-color-green-60) 40%, transparent)`)
+- `--fill-color-4`: Fill color for the fourth dataset. (Default: `color-mix(in srgb, var(--wa-color-yellow-60) 40%, transparent)`)
+- `--fill-color-5`: Fill color for the fifth dataset. (Default: `color-mix(in srgb, var(--wa-color-purple-60) 40%, transparent)`)
+- `--fill-color-6`: Fill color for the sixth dataset. (Default: `color-mix(in srgb, var(--wa-color-orange-60) 40%, transparent)`)
+- `--border-color-1`: Border color for the first dataset. (Default: `var(--wa-color-blue-60)`)
+- `--border-color-2`: Border color for the second dataset. (Default: `var(--wa-color-pink-60)`)
+- `--border-color-3`: Border color for the third dataset. (Default: `var(--wa-color-green-60)`)
+- `--border-color-4`: Border color for the fourth dataset. (Default: `var(--wa-color-yellow-60)`)
+- `--border-color-5`: Border color for the fifth dataset. (Default: `var(--wa-color-purple-60)`)
+- `--border-color-6`: Border color for the sixth dataset. (Default: `var(--wa-color-orange-60)`)
+- `--grid-color`: Color of the chart grid lines and axis borders. (Default: `var(--wa-color-neutral-border-quiet)`)
+- `--border-width`: Border width for bars and arcs. (Default: `var(--wa-border-width-s)`)
+- `--border-radius`: Border radius for bar charts. (Default: `var(--wa-border-radius-s)`)
+- `--grid-border-width`: Border width for chart grid lines and axis borders. (Default: `var(--wa-border-width-s)`)
+- `--line-border-width`: Border width for line and radar charts. (Default: `var(--wa-border-width-m)`)
+- `--point-radius`: Radius of data point dots. (Default: `var(--wa-border-width-m)`)
+
+#### `<wa-markdown>`
+
+**Description:** Markdown elements render markdown content as HTML directly in the browser, making it easy to display user-generated content or documentation without a server-side build step.
+
+**Documentation:** https://webawesome.com/docs/components/markdown
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `tabSize` (attribute: `tab-size`): The tab stop width used when converting leading tabs to spaces during whitespace normalization. (Type: `number`, Default: `4`)
+- `marked`: A reference to the shared Marked instance for convenience. Equivalent to `WaMarkdown.getMarked()`. (Type: `Marked`)
+
+**Methods:**
+
+- `getMarked()`: Returns the shared Marked instance used by all `<wa-markdown>` components.
+- `updateAll()`: Re-renders all connected `<wa-markdown>` instances. Call this after changing the Marked configuration.
+- `renderMarkdown()`: Reads the script content, normalizes whitespace, parses markdown, and injects the result.
+
+#### `<wa-mutation-observer>`
+
+**Description:** Mutation observers watch for changes to an element's DOM tree and emit an event when they occur. Provides a thin, declarative interface to the browser's MutationObserver API.
+
+**Documentation:** https://webawesome.com/docs/components/mutation-observer
+
+**Slots:**
+
+- `(default)`: The content to watch for mutations.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `attr`: Watches for changes to attributes. To watch only specific attributes, separate them by a space, e.g. `attr="class id title"`. To watch all attributes, use `*`. (Type: `string`)
+- `attrOldValue` (attribute: `attr-old-value`): Indicates whether or not the attribute's previous value should be recorded when monitoring changes. (Type: `boolean`, Default: `false`)
+- `charData` (attribute: `char-data`): Watches for changes to the character data contained within the node. (Type: `boolean`, Default: `false`)
+- `charDataOldValue` (attribute: `char-data-old-value`): Indicates whether or not the previous value of the node's text should be recorded. (Type: `boolean`, Default: `false`)
+- `childList` (attribute: `child-list`): Watches for the addition or removal of new child nodes. (Type: `boolean`, Default: `false`)
+- `disabled`: Disables the observer. (Type: `boolean`, Default: `false`)
+
+**Events:**
+
+- `wa-mutation`: Emitted when a mutation occurs.
+
+#### `<wa-number-input>`
+
+**Description:** Number inputs let users enter and edit numeric values, with optional stepper buttons for incrementing and decrementing. Use them for quantities, measurements, and other numeric form fields.
+
+**Documentation:** https://webawesome.com/docs/components/number-input
+
+**Slots:**
+
+- `label`: The input's label. Alternatively, you can use the `label` attribute.
+- `start`: An element, such as `<wa-icon>`, placed at the start of the input control.
+- `end`: An element, such as `<wa-icon>`, placed at the end of the input control (before steppers).
+- `increment-icon`: An icon to use in lieu of the default increment icon.
+- `decrement-icon`: An icon to use in lieu of the default decrement icon.
+- `hint`: Text that describes how to use the input. Alternatively, you can use the `hint` attribute.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[sizeStyles, formControlStyles, styles]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `value`: The current value of the input, submitted as a name/value pair with form data.
+- `defaultValue` (attribute: `value`): The default value of the form control. Primarily used for resetting the form control. (Type: `string | null`)
+- `size`: The input's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `appearance`: The input's visual appearance. (Type: `'filled' | 'outlined' | 'filled-outlined'`, Default: `'outlined'`)
+- `pill`: Draws a pill-style input with rounded edges. (Type: `boolean`, Default: `false`)
+- `label`: The input's label. If you need to display HTML, use the `label` slot instead. (Type: `string`, Default: `''`)
+- `hint`: The input's hint. If you need to display HTML, use the `hint` slot instead. (Type: `string`, Default: `''`)
+- `placeholder`: Placeholder text to show as a hint when the input is empty. (Type: `string`, Default: `''`)
+- `readonly`: Makes the input readonly. (Type: `boolean`, Default: `false`)
+- `required`: Makes the input a required field. (Type: `boolean`, Default: `false`)
+- `min`: The input's minimum value. (Type: `number`)
+- `max`: The input's maximum value. (Type: `number`)
+- `step`: Specifies the granularity that the value must adhere to, or the special value `any` which means no stepping is implied, allowing any numeric value. (Type: `number | 'any'`, Default: `1`)
+- `withoutSteppers` (attribute: `without-steppers`): Hides the increment/decrement stepper buttons. (Type: `boolean`, Default: `false`)
+- `autocomplete`: Specifies what permission the browser has to provide assistance in filling out form field values. Refer to [this page on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) for available values. (Type: `string`)
+- `autofocus`: Indicates that the input should receive focus on page load. (Type: `boolean`)
+- `enterkeyhint`: Used to customize the label or icon of the Enter key on virtual keyboards. (Type: `'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send'`)
+- `inputmode`: Tells the browser what type of data will be entered by the user, allowing it to display the appropriate virtual keyboard on supportive devices. (Type: `'numeric' | 'decimal'`, Default: `'numeric'`)
+- `withLabel` (attribute: `with-label`): Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup includes the label before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withHint` (attribute: `with-hint`): Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup includes the hint before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `name`: The name of the input, submitted as a name/value pair with form data. (Type: `string | null`, Default: `null`)
+- `disabled`: Disables the form control. (Type: `boolean`, Default: `false`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+- `validationTarget`: Override this to change where constraint validation popups are anchored. (Type: `undefined | HTMLElement`)
+
+**Methods:**
+
+- `focus(options: FocusOptions)`: Sets focus on the input.
+- `blur()`: Removes focus from the input.
+- `select()`: Selects all the text in the input.
+- `stepUp()`: Increments the value by the step amount.
+- `stepDown()`: Decrements the value by the step amount.
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `input`: Emitted when the control receives input.
+- `change`: Emitted when an alteration to the control's value is committed by the user.
+- `blur`: Emitted when the control loses focus.
+- `focus`: Emitted when the control gains focus.
+- `beforeinput`: Emitted before the value changes. Can be cancelled with `event.preventDefault()` to prevent the value from changing.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Parts:**
+
+- `label`: The label element.
+- `form-control-label`: Alias for the label element.
+- `hint`: The hint element.
+- `base`: The wrapper containing the input and steppers.
+- `input`: The internal `<input>` control.
+- `start`: The container that wraps the `start` slot.
+- `end`: The container that wraps the `end` slot.
+- `stepper`: Both stepper buttons (for shared styling).
+- `stepper-increment`: The increment (+) button on the end side.
+- `stepper-decrement`: The decrement (-) button on the start side.
+
+**CSS States:**
+
+- `blank`: The input is empty.
+- `focused`: The input has focus.
+
+#### `<wa-option>`
+
+**Description:** Options represent the individual choices inside a select or similar form control. Each option holds a value and the label shown to the user.
+
+**Documentation:** https://webawesome.com/docs/components/option
+
+**Slots:**
+
+- `(default)`: The option's label.
+- `start`: An element, such as `<wa-icon>`, placed before the label.
+- `end`: An element, such as `<wa-icon>`, placed after the label.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `value`: The option's value. When selected, the containing form control will receive this value. The value must be unique from other options in the same group. Values may not contain spaces, as spaces are used as delimiters when listing multiple values. (Type: `string`, Default: `''`)
+- `disabled`: Draws the option in a disabled state, preventing selection. (Type: `boolean`, Default: `false`)
+- `defaultSelected` (attribute: `selected`): Selects an option initially. (Type: `boolean`, Default: `false`)
+- `label`: The option’s plain text label. Usually automatically generated, but can be useful to provide manually for cases involving complex content. (Type: `string`)
+- `defaultLabel`: The default label, generated from the element contents. Will be equal to `label` in most cases. (Type: `string`)
+
+**CSS Parts:**
+
+- `checked-icon`: The checked icon, a `<wa-icon>` element.
+- `label`: The option's label.
+- `start`: The container that wraps the `start` slot.
+- `end`: The container that wraps the `end` slot.
+
+**CSS States:**
+
+- `current`: The user has keyed into the option, but hasn't selected it yet (shows a highlight)
+- `selected`: The option is selected and has aria-selected="true"
+- `disabled`: Applied when the option is disabled
+- `hover`: Like `:hover` but works while dragging in Safari
+
+#### `<wa-page>`
+
+**Description:** Pages scaffold an entire application layout with header, navigation, sidebar, main content, aside, and footer regions. Use them to structure full pages with minimal markup and responsive behavior built in.
+
+**Documentation:** https://webawesome.com/docs/components/page
+
+**Slots:**
+
+- `(default)`: The page's main content.
+- `banner`: The banner that gets display above the header. The banner will not be shown if no content is provided.
+- `header`: The header to display at the top of the page. If a banner is present, the header will appear below the banner. The header will not be shown if there is no content.
+- `subheader`: A subheader to display below the `header`. This is a good place to put things like breadcrumbs.
+- `menu`: The left side of the page. If you slot an element in here, you will override the default `navigation` slot and will be handling navigation on your own. This also will not disable the fallback behavior of the navigation button. This section "sticks" to the top as the page scrolls.
+- `navigation-header`: The header for a navigation area. On mobile this will be the header for `<wa-drawer>`.
+- `navigation`: The main content to display in the navigation area. This is displayed on the left side of the page, if `menu` is not used. This section "sticks" to the top as the page scrolls.
+- `navigation-footer`: The footer for a navigation area. On mobile this will be the footer for `<wa-drawer>`.
+- `navigation-toggle`: Use this slot to slot in your own button + icon for toggling the navigation drawer. By default it is a `<wa-button>` + a 3 bars `<wa-icon>`
+- `navigation-toggle-icon`: Use this to slot in your own icon for toggling the navigation drawer. By default it is 3 bars `<wa-icon>`.
+- `main-header`: Header to display inline above the main content.
+- `main-footer`: Footer to display inline below the main content.
+- `aside`: Content to be shown on the right side of the page. Typically contains a table of contents, ads, etc. This section "sticks" to the top as the page scrolls.
+- `skip-to-content`: The "skip to content" slot. You can override this If you would like to override the `Skip to content` button and add additional "Skip to X", they can be inserted here.
+- `footer`: The content to display in the footer. This is always displayed underneath the viewport so will always make the page "scrollable".
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[visuallyHidden, styles]`)
+- `view`: The view is a reflection of the "mobileBreakpoint", when the page is larger than the `mobile-breakpoint` (768px by default), it is considered to be a "desktop" view. The view is merely a way to distinguish when to show/hide the navigation. You can use additional media queries to make other adjustments to content as necessary. The default is "desktop" because the "mobile navigation drawer" isn't accessible via SSR due to drawer requiring JS. (Type: `'mobile' | 'desktop'`, Default: `'desktop'`)
+- `navOpen` (attribute: `nav-open`): Whether or not the navigation drawer is open. Note, the navigation drawer is only "open" on mobile views. (Type: `boolean`, Default: `false`)
+- `mobileBreakpoint` (attribute: `mobile-breakpoint`): At what page width to hide the "navigation" slot and collapse into a hamburger button. Accepts both numbers (interpreted as px) and CSS lengths (e.g. `50em`), which are resolved based on the root element. (Type: `string`, Default: `'768px'`)
+- `navigationPlacement` (attribute: `navigation-placement`): Where to place the navigation when in the mobile viewport. (Type: `'start' | 'end'`, Default: `'start'`)
+- `disableNavigationToggle` (attribute: `disable-navigation-toggle`): Determines whether or not to hide the default hamburger button. This will automatically flip to "true" if you add an element with `data-toggle-nav` anywhere in the element light DOM. Generally this will be set for you and you don't need to do anything, unless you're using SSR, in which case you should set this manually for initial page loads. (Type: `boolean`, Default: `false`)
+
+**Methods:**
+
+- `visiblePixelsInViewport(element: HTMLElement | null)`: https://stackoverflow.com/a/26831113 This prevents awkward gaps when scrolling the page and the aside / menu dont "fill" the gaps.
+- `showNavigation()`: Shows the mobile navigation drawer
+- `hideNavigation()`: Hides the mobile navigation drawer
+- `toggleNavigation()`: Toggles the mobile navigation drawer
+
+**CSS Custom Properties:**
+
+- `--menu-width`: The width of the page's "menu" section. (Default: `auto`)
+- `--main-width`: The width of the page's "main" section. (Default: `1fr`)
+- `--aside-width`: The wide of the page's "aside" section. (Default: `auto`)
+- `--banner-height`: The height of the banner. This gets calculated when the page initializes. If the height is known, you can set it here to prevent shifting when the page loads. (Default: `0px`)
+- `--header-height`: The height of the header. This gets calculated when the page initializes. If the height is known, you can set it here to prevent shifting when the page loads. (Default: `0px`)
+- `--subheader-height`: The height of the subheader. This gets calculated when the page initializes. If the height is known, you can set it here to prevent shifting when the page loads. (Default: `0px`)
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+- `banner`: The banner to show above header.
+- `header`: The header, usually for top level navigation / branding.
+- `subheader`: Shown below the header, usually intended for things like breadcrumbs and other page level navigation.
+- `body`: The wrapper around menu, main, and aside.
+- `menu`: The left hand side of the page. Generally intended for navigation.
+- `navigation`: The `<nav>` that wraps the navigation slots on desktop viewports.
+- `navigation-header`: The header for a navigation area. On mobile this will be the header for `<wa-drawer>`.
+- `navigation-footer`: The footer for a navigation area. On mobile this will be the footer for `<wa-drawer>`.
+- `navigation-toggle`: The default `<wa-button>` that will toggle the `<wa-drawer>` for mobile viewports.
+- `navigation-toggle-icon`: The default `<wa-icon>` displayed inside of the navigation-toggle button.
+- `main-header`: The header above main content.
+- `main-content`: The main content.
+- `main-footer`: The footer below main content.
+- `aside`: The right hand side of the page. Used for things like table of contents, ads, etc.
+- `skip-links`: Wrapper around skip-link
+- `skip-link`: The "skip to main content" link
+- `footer`: The footer of the page. This is always below the initial viewport size.
+- `dialog-wrapper`: A wrapper around elements such as dialogs or other modal-like elements.
+
+#### `<wa-pie-chart>`
+
+**Description:** Pie charts show the proportional composition of a whole as slices of a circle. They work best with a small number of categories where the relative proportions matter more than exact values.
+
+**Documentation:** https://webawesome.com/docs/components/pie-chart
+
+**Slots:**
+
+- `(default)`: An optional `<script type="application/json">` element containing the Chart.js configuration object.
+
+**Properties:**
+
+- `type`: The type of chart to render. Valid types include `bar`, `line`, `pie`, `doughnut`, `polarArea`, `radar`, `scatter`, and `bubble`. (Type: `ChartType`, Default: `'pie'`)
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles]`)
+- `label`: A label for the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `description`: A description of the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `xLabel`: A label for the x-axis. (Type: `string | null`, Default: `null`)
+- `yLabel`: A label for the y-axis. (Type: `string | null`, Default: `null`)
+- `legendPosition` (attribute: `legend-position`): The position of the legend relative to the chart. (Type: `LayoutPosition | 'start' | 'end'`, Default: `'top'`)
+- `stacked`: Stacks datasets on top of each other along the value axis. (Type: `boolean`, Default: `false`)
+- `indexAxis` (attribute: `index-axis`): The base axis of the dataset. 'x' for vertical bars and 'y' for horizontal bars. (Type: `'x' | 'y'`, Default: `'x'`)
+- `grid`: Which axes to show grid lines on. (Type: `'x' | 'y' | 'both' | 'none'`, Default: `'both'`)
+- `min`: The minimum value for the value axis. (Type: `number | null`, Default: `null`)
+- `max`: The maximum value for the value axis. (Type: `number | null`, Default: `null`)
+- `withoutAnimation` (attribute: `without-animation`): Disables chart animations (Type: `boolean`, Default: `false`)
+- `withoutLegend` (attribute: `without-legend`): Hides the legend (Type: `boolean`, Default: `false`)
+- `withoutTooltip` (attribute: `without-tooltip`): Hides tooltips over data points (Type: `boolean`, Default: `false`)
+- `config`: The Chart.js configuration object. Setting this property will automatically re-render the chart. (Type: `ChartJS['config']`)
+- `plugins`: Additional Chart.js plugins to register for this chart instance. (Type: `array`, Default: `[]`)
+
+**CSS Custom Properties:**
+
+- `--fill-color-1`: Fill color for the first dataset. (Default: `color-mix(in srgb, var(--wa-color-blue-60) 40%, transparent)`)
+- `--fill-color-2`: Fill color for the second dataset. (Default: `color-mix(in srgb, var(--wa-color-pink-60) 40%, transparent)`)
+- `--fill-color-3`: Fill color for the third dataset. (Default: `color-mix(in srgb, var(--wa-color-green-60) 40%, transparent)`)
+- `--fill-color-4`: Fill color for the fourth dataset. (Default: `color-mix(in srgb, var(--wa-color-yellow-60) 40%, transparent)`)
+- `--fill-color-5`: Fill color for the fifth dataset. (Default: `color-mix(in srgb, var(--wa-color-purple-60) 40%, transparent)`)
+- `--fill-color-6`: Fill color for the sixth dataset. (Default: `color-mix(in srgb, var(--wa-color-orange-60) 40%, transparent)`)
+- `--border-color-1`: Border color for the first dataset. (Default: `var(--wa-color-blue-60)`)
+- `--border-color-2`: Border color for the second dataset. (Default: `var(--wa-color-pink-60)`)
+- `--border-color-3`: Border color for the third dataset. (Default: `var(--wa-color-green-60)`)
+- `--border-color-4`: Border color for the fourth dataset. (Default: `var(--wa-color-yellow-60)`)
+- `--border-color-5`: Border color for the fifth dataset. (Default: `var(--wa-color-purple-60)`)
+- `--border-color-6`: Border color for the sixth dataset. (Default: `var(--wa-color-orange-60)`)
+- `--grid-color`: Color of the chart grid lines and axis borders. (Default: `var(--wa-color-neutral-border-quiet)`)
+- `--border-width`: Border width for bars and arcs. (Default: `var(--wa-border-width-s)`)
+- `--border-radius`: Border radius for bar charts. (Default: `var(--wa-border-radius-s)`)
+- `--grid-border-width`: Border width for chart grid lines and axis borders. (Default: `var(--wa-border-width-s)`)
+- `--line-border-width`: Border width for line and radar charts. (Default: `var(--wa-border-width-m)`)
+- `--point-radius`: Radius of data point dots. (Default: `var(--wa-border-width-m)`)
+
+#### `<wa-polar-area-chart>`
+
+**Description:** Polar area charts compare values using segments that radiate from a center point with varying radius. Unlike pie charts, each segment has an equal angle while the radius varies, making them useful for comparing magnitudes without visual bias.
+
+**Documentation:** https://webawesome.com/docs/components/polar-area-chart
+
+**Slots:**
+
+- `(default)`: An optional `<script type="application/json">` element containing the Chart.js configuration object.
+
+**Properties:**
+
+- `type`: The type of chart to render. Valid types include `bar`, `line`, `pie`, `doughnut`, `polarArea`, `radar`, `scatter`, and `bubble`. (Type: `ChartType`, Default: `'polarArea'`)
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles]`)
+- `label`: A label for the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `description`: A description of the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `xLabel`: A label for the x-axis. (Type: `string | null`, Default: `null`)
+- `yLabel`: A label for the y-axis. (Type: `string | null`, Default: `null`)
+- `legendPosition` (attribute: `legend-position`): The position of the legend relative to the chart. (Type: `LayoutPosition | 'start' | 'end'`, Default: `'top'`)
+- `stacked`: Stacks datasets on top of each other along the value axis. (Type: `boolean`, Default: `false`)
+- `indexAxis` (attribute: `index-axis`): The base axis of the dataset. 'x' for vertical bars and 'y' for horizontal bars. (Type: `'x' | 'y'`, Default: `'x'`)
+- `grid`: Which axes to show grid lines on. (Type: `'x' | 'y' | 'both' | 'none'`, Default: `'both'`)
+- `min`: The minimum value for the value axis. (Type: `number | null`, Default: `null`)
+- `max`: The maximum value for the value axis. (Type: `number | null`, Default: `null`)
+- `withoutAnimation` (attribute: `without-animation`): Disables chart animations (Type: `boolean`, Default: `false`)
+- `withoutLegend` (attribute: `without-legend`): Hides the legend (Type: `boolean`, Default: `false`)
+- `withoutTooltip` (attribute: `without-tooltip`): Hides tooltips over data points (Type: `boolean`, Default: `false`)
+- `config`: The Chart.js configuration object. Setting this property will automatically re-render the chart. (Type: `ChartJS['config']`)
+- `plugins`: Additional Chart.js plugins to register for this chart instance. (Type: `array`, Default: `[]`)
+
+**CSS Custom Properties:**
+
+- `--fill-color-1`: Fill color for the first dataset. (Default: `color-mix(in srgb, var(--wa-color-blue-60) 40%, transparent)`)
+- `--fill-color-2`: Fill color for the second dataset. (Default: `color-mix(in srgb, var(--wa-color-pink-60) 40%, transparent)`)
+- `--fill-color-3`: Fill color for the third dataset. (Default: `color-mix(in srgb, var(--wa-color-green-60) 40%, transparent)`)
+- `--fill-color-4`: Fill color for the fourth dataset. (Default: `color-mix(in srgb, var(--wa-color-yellow-60) 40%, transparent)`)
+- `--fill-color-5`: Fill color for the fifth dataset. (Default: `color-mix(in srgb, var(--wa-color-purple-60) 40%, transparent)`)
+- `--fill-color-6`: Fill color for the sixth dataset. (Default: `color-mix(in srgb, var(--wa-color-orange-60) 40%, transparent)`)
+- `--border-color-1`: Border color for the first dataset. (Default: `var(--wa-color-blue-60)`)
+- `--border-color-2`: Border color for the second dataset. (Default: `var(--wa-color-pink-60)`)
+- `--border-color-3`: Border color for the third dataset. (Default: `var(--wa-color-green-60)`)
+- `--border-color-4`: Border color for the fourth dataset. (Default: `var(--wa-color-yellow-60)`)
+- `--border-color-5`: Border color for the fifth dataset. (Default: `var(--wa-color-purple-60)`)
+- `--border-color-6`: Border color for the sixth dataset. (Default: `var(--wa-color-orange-60)`)
+- `--grid-color`: Color of the chart grid lines and axis borders. (Default: `var(--wa-color-neutral-border-quiet)`)
+- `--border-width`: Border width for bars and arcs. (Default: `var(--wa-border-width-s)`)
+- `--border-radius`: Border radius for bar charts. (Default: `var(--wa-border-radius-s)`)
+- `--grid-border-width`: Border width for chart grid lines and axis borders. (Default: `var(--wa-border-width-s)`)
+- `--line-border-width`: Border width for line and radar charts. (Default: `var(--wa-border-width-m)`)
+- `--point-radius`: Radius of data point dots. (Default: `var(--wa-border-width-m)`)
+
+#### `<wa-popover>`
+
+**Description:** Popovers display contextual content and interactive elements in a floating panel anchored to a trigger. Use them for rich tooltips, menus, or any content that appears on demand without navigating away.
+
+**Documentation:** https://webawesome.com/docs/components/popover
+
+**Slots:**
+
+- `(default)`: The popover's content. Interactive elements such as buttons and links are supported.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `placement`: The preferred placement of the popover. Note that the actual placement may vary as needed to keep the popover inside of the viewport. (Type: `| 'top'     | 'top-start'     | 'top-end'     | 'right'     | 'right-start'     | 'right-end'     | 'bottom'     | 'bottom-start'     | 'bottom-end'     | 'left'     | 'left-start'     | 'left-end'`, Default: `'top'`)
+- `open`: Shows or hides the popover. (Type: `boolean`, Default: `false`)
+- `distance`: The distance in pixels from which to offset the popover away from its target. (Type: `number`, Default: `8`)
+- `skidding`: The distance in pixels from which to offset the popover along its target. (Type: `number`, Default: `0`)
+- `for`: The ID of the popover's anchor element. This must be an interactive/focusable element such as a button. (Type: `string | null`, Default: `null`)
+- `withoutArrow` (attribute: `without-arrow`): Removes the arrow from the popover. (Type: `boolean`, Default: `false`)
+
+**Methods:**
+
+- `show()`: Shows the popover.
+- `hide()`: Hides the popover.
+
+**Events:**
+
+- `wa-show`: Emitted when the popover begins to show. Canceling this event will stop the popover from showing.
+- `wa-after-show`: Emitted after the popover has shown and all animations are complete.
+- `wa-hide`: Emitted when the popover begins to hide. Canceling this event will stop the popover from hiding.
+- `wa-after-hide`: Emitted after the popover has hidden and all animations are complete.
+
+**CSS Custom Properties:**
+
+- `--arrow-size`: The size of the tiny arrow that points to the popover (set to zero to remove). (Default: `0.375rem`)
+- `--max-width`: The maximum width of the popover's body content. (Default: `25rem`)
+- `--show-duration`: The speed of the show animation. (Default: `100ms`)
+- `--hide-duration`: The speed of the hide animation. (Default: `100ms`)
+
+**CSS Parts:**
+
+- `dialog`: The native dialog element that contains the popover content.
+- `body`: The popover's body where its content is rendered.
+- `popup`: The internal `<wa-popup>` element that positions the popover.
+- `popup__popup`: The popup's exported `popup` part. Use this to target the popover's popup container.
+- `popup__arrow`: The popup's exported `arrow` part. Use this to target the popover's arrow.
+
+**CSS States:**
+
+- `open`: Applied when the popover is open.
+
+#### `<wa-popup>`
+
+**Description:** Popups declaratively anchor one element to another and keep them positioned together as the page scrolls or resizes. Primarily a low-level building block for popovers, dropdowns, and tooltips.
+
+**Documentation:** https://webawesome.com/docs/components/popup
+
+**Slots:**
+
+- `(default)`: The popup's content.
+- `anchor`: The element the popup will be anchored to. If the anchor lives outside of the popup, you can use the `anchor` attribute or property instead.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `popup`: A reference to the internal popup container. Useful for animating and styling the popup with JavaScript. (Type: `HTMLElement`)
+- `anchor`: The element the popup will be anchored to. If the anchor lives outside of the popup, you can provide the anchor element `id`, a DOM element reference, or a `VirtualElement`. If the anchor lives inside the popup, use the `anchor` slot instead. (Type: `Element | string | VirtualElement`)
+- `active`: Activates the positioning logic and shows the popup. When this attribute is removed, the positioning logic is torn down and the popup will be hidden. (Type: `boolean`, Default: `false`)
+- `placement`: The preferred placement of the popup. Note that the actual placement will vary as configured to keep the panel inside of the viewport. (Type: `| 'top'     | 'top-start'     | 'top-end'     | 'bottom'     | 'bottom-start'     | 'bottom-end'     | 'right'     | 'right-start'     | 'right-end'     | 'left'     | 'left-start'     | 'left-end'`, Default: `'top'`)
+- `boundary`: The bounding box to use for flipping, shifting, and auto-sizing. (Type: `'viewport' | 'scroll'`, Default: `'viewport'`)
+- `distance`: The distance in pixels from which to offset the panel away from its anchor. (Type: `number`, Default: `0`)
+- `skidding`: The distance in pixels from which to offset the panel along its anchor. (Type: `number`, Default: `0`)
+- `arrow`: Attaches an arrow to the popup. The arrow's size and color can be customized using the `--arrow-size` and `--arrow-color` custom properties. For additional customizations, you can also target the arrow using `::part(arrow)` in your stylesheet. (Type: `boolean`, Default: `false`)
+- `arrowPlacement` (attribute: `arrow-placement`): The placement of the arrow. The default is `anchor`, which will align the arrow as close to the center of the anchor as possible, considering available space and `arrow-padding`. A value of `start`, `end`, or `center` will align the arrow to the start, end, or center of the popover instead. (Type: `'start' | 'end' | 'center' | 'anchor'`, Default: `'anchor'`)
+- `arrowPadding` (attribute: `arrow-padding`): The amount of padding between the arrow and the edges of the popup. If the popup has a border-radius, for example, this will prevent it from overflowing the corners. (Type: `number`, Default: `10`)
+- `flip`: When set, placement of the popup will flip to the opposite site to keep it in view. You can use `flipFallbackPlacements` to further configure how the fallback placement is determined. (Type: `boolean`, Default: `false`)
+- `flipFallbackPlacements` (attribute: `flip-fallback-placements`): If the preferred placement doesn't fit, popup will be tested in these fallback placements until one fits. Must be a string of any number of placements separated by a space, e.g. "top bottom left". If no placement fits, the flip fallback strategy will be used instead. (Type: `string`, Default: `''`)
+- `flipFallbackStrategy` (attribute: `flip-fallback-strategy`): When neither the preferred placement nor the fallback placements fit, this value will be used to determine whether the popup should be positioned using the best available fit based on available space or as it was initially preferred. (Type: `'best-fit' | 'initial'`, Default: `'best-fit'`)
+- `flipBoundary`: The flip boundary describes clipping element(s) that overflow will be checked relative to when flipping. By default, the boundary includes overflow ancestors that will cause the element to be clipped. If needed, you can change the boundary by passing a reference to one or more elements to this property. (Type: `Element | Element[]`)
+- `flipPadding` (attribute: `flip-padding`): The amount of padding, in pixels, to exceed before the flip behavior will occur. (Type: `number`, Default: `0`)
+- `shift`: Moves the popup along the axis to keep it in view when clipped. (Type: `boolean`, Default: `false`)
+- `shiftBoundary`: The shift boundary describes clipping element(s) that overflow will be checked relative to when shifting. By default, the boundary includes overflow ancestors that will cause the element to be clipped. If needed, you can change the boundary by passing a reference to one or more elements to this property. (Type: `Element | Element[]`)
+- `shiftPadding` (attribute: `shift-padding`): The amount of padding, in pixels, to exceed before the shift behavior will occur. (Type: `number`, Default: `0`)
+- `autoSize` (attribute: `auto-size`): When set, this will cause the popup to automatically resize itself to prevent it from overflowing. (Type: `'horizontal' | 'vertical' | 'both'`)
+- `sync`: Syncs the popup's width or height to that of the anchor element. (Type: `'width' | 'height' | 'both'`)
+- `autoSizeBoundary`: The auto-size boundary describes clipping element(s) that overflow will be checked relative to when resizing. By default, the boundary includes overflow ancestors that will cause the element to be clipped. If needed, you can change the boundary by passing a reference to one or more elements to this property. (Type: `Element | Element[]`)
+- `autoSizePadding` (attribute: `auto-size-padding`): The amount of padding, in pixels, to exceed before the auto-size behavior will occur. (Type: `number`, Default: `0`)
+- `hoverBridge` (attribute: `hover-bridge`): When a gap exists between the anchor and the popup element, this option will add a "hover bridge" that fills the gap using an invisible element. This makes listening for events such as `mouseenter` and `mouseleave` more sane because the pointer never technically leaves the element. The hover bridge will only be drawn when the popover is active. (Type: `boolean`, Default: `false`)
+
+**Methods:**
+
+- `reposition()`: Forces the popup to recalculate and reposition itself.
+
+**Events:**
+
+- `wa-reposition`: Emitted when the popup is repositioned. This event can fire a lot, so avoid putting expensive operations in your listener or consider debouncing it.
+
+**CSS Custom Properties:**
+
+- `--arrow-size`: The size of the arrow. Note that an arrow won't be shown unless the `arrow` attribute is used. (Default: `6px`)
+- `--popup-border-width`: The width of any custom border applied to the popup. This is used to reposition the arrow to overlap to the inside edge of the popup border.
+- `--arrow-color`: The color of the arrow. (Default: `black`)
+- `--auto-size-available-width`: A read-only custom property that determines the amount of width the popup can be before overflowing. Useful for positioning child elements that need to overflow. This property is only available when using `auto-size`.
+- `--auto-size-available-height`: A read-only custom property that determines the amount of height the popup can be before overflowing. Useful for positioning child elements that need to overflow. This property is only available when using `auto-size`.
+- `--show-duration`: The show duration to use when applying built-in animation classes. (Default: `100ms`)
+- `--hide-duration`: The hide duration to use when applying built-in animation classes. (Default: `100ms`)
+
+**CSS Parts:**
+
+- `arrow`: The arrow's container. Avoid setting `top|bottom|left|right` properties, as these values are assigned dynamically as the popup moves. This is most useful for applying a background color to match the popup, and maybe a border or box shadow.
+- `popup`: The popup's container. Useful for setting a background color, box shadow, etc.
+- `hover-bridge`: The hover bridge element. Only available when the `hover-bridge` option is enabled.
+
+#### `<wa-progress-bar>`
+
+**Description:** Progress bars show how far along an ongoing operation is as a horizontal fill. Use them for file uploads, multi-step flows, or any task with measurable progress.
+
+**Documentation:** https://webawesome.com/docs/components/progress-bar
+
+**Slots:**
+
+- `(default)`: A label to show inside the progress indicator.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `value`: The current progress as a percentage, 0 to 100. (Type: `number`, Default: `0`)
+- `indeterminate`: When true, percentage is ignored, the label is hidden, and the progress bar is drawn in an indeterminate state. (Type: `boolean`, Default: `false`)
+- `label`: A custom label for assistive devices. (Type: `string`, Default: `''`)
+
+**CSS Custom Properties:**
+
+- `--track-height`: The color of the track. (Default: `1rem`)
+- `--track-color`: The color of the track. (Default: `var(--wa-color-neutral-fill-normal)`)
+- `--indicator-color`: The color of the indicator. (Default: `var(--wa-color-brand-fill-loud)`)
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+- `indicator`: The progress bar's indicator.
+- `label`: The progress bar's label.
+
+#### `<wa-progress-ring>`
+
+**Description:** Progress rings show how far along a determinate operation is using a circular indicator. Use them as a compact alternative to progress bars when horizontal space is limited.
+
+**Documentation:** https://webawesome.com/docs/components/progress-ring
+
+**Slots:**
+
+- `(default)`: A label to show inside the ring.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `value`: The current progress as a percentage, 0 to 100. (Type: `number`, Default: `0`)
+- `label`: A custom label for assistive devices. (Type: `string`, Default: `''`)
+
+**CSS Custom Properties:**
+
+- `--size`: The diameter of the progress ring (cannot be a percentage).
+- `--track-width`: The width of the track.
+- `--track-color`: The color of the track.
+- `--indicator-width`: The width of the indicator. Defaults to the track width.
+- `--indicator-color`: The color of the indicator.
+- `--indicator-transition-duration`: The duration of the indicator's transition when the value changes.
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+- `label`: The progress ring label.
+- `track`: The progress ring's track.
+- `indicator`: The progress ring's indicator.
+
+#### `<wa-qr-code>`
+
+**Description:** QR codes encode a URL or other short text into a scannable image, rendered client-side using the Canvas API. Use them to share links, contact info, or Wi-Fi credentials that visitors can scan with a phone.
+
+**Documentation:** https://webawesome.com/docs/components/qr-code
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `value`: The QR code's value. (Type: `string`, Default: `''`)
+- `label`: The label for assistive devices to announce. If unspecified, the value will be used instead. (Type: `string`, Default: `''`)
+- `size`: The size of the QR code, in pixels. (Type: `number`, Default: `128`)
+- `fill`: The fill color. This can be any valid CSS color, but not a CSS custom property. (Type: `string`, Default: `''`)
+- `background`: The background color. This can be any valid CSS color or `transparent`. It cannot be a CSS custom property. (Type: `string`, Default: `''`)
+- `radius`: The edge radius of each module. Must be between 0 and 0.5. (Type: `number`, Default: `0`)
+- `errorCorrection` (attribute: `error-correction`): The level of error correction to use. [Learn more](https://www.qrcode.com/en/about/error_correction.html) (Type: `'L' | 'M' | 'Q' | 'H'`, Default: `'H'`)
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+
+#### `<wa-radar-chart>`
+
+**Description:** Radar charts compare multiple variables at once by plotting data on a radial grid. They are well-suited for comparing profiles across several dimensions, such as skill assessments, product attributes, or performance metrics.
+
+**Documentation:** https://webawesome.com/docs/components/radar-chart
+
+**Slots:**
+
+- `(default)`: An optional `<script type="application/json">` element containing the Chart.js configuration object.
+
+**Properties:**
+
+- `type`: The type of chart to render. Valid types include `bar`, `line`, `pie`, `doughnut`, `polarArea`, `radar`, `scatter`, and `bubble`. (Type: `ChartType`, Default: `'radar'`)
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles]`)
+- `label`: A label for the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `description`: A description of the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `xLabel`: A label for the x-axis. (Type: `string | null`, Default: `null`)
+- `yLabel`: A label for the y-axis. (Type: `string | null`, Default: `null`)
+- `legendPosition` (attribute: `legend-position`): The position of the legend relative to the chart. (Type: `LayoutPosition | 'start' | 'end'`, Default: `'top'`)
+- `stacked`: Stacks datasets on top of each other along the value axis. (Type: `boolean`, Default: `false`)
+- `indexAxis` (attribute: `index-axis`): The base axis of the dataset. 'x' for vertical bars and 'y' for horizontal bars. (Type: `'x' | 'y'`, Default: `'x'`)
+- `grid`: Which axes to show grid lines on. (Type: `'x' | 'y' | 'both' | 'none'`, Default: `'both'`)
+- `min`: The minimum value for the value axis. (Type: `number | null`, Default: `null`)
+- `max`: The maximum value for the value axis. (Type: `number | null`, Default: `null`)
+- `withoutAnimation` (attribute: `without-animation`): Disables chart animations (Type: `boolean`, Default: `false`)
+- `withoutLegend` (attribute: `without-legend`): Hides the legend (Type: `boolean`, Default: `false`)
+- `withoutTooltip` (attribute: `without-tooltip`): Hides tooltips over data points (Type: `boolean`, Default: `false`)
+- `config`: The Chart.js configuration object. Setting this property will automatically re-render the chart. (Type: `ChartJS['config']`)
+- `plugins`: Additional Chart.js plugins to register for this chart instance. (Type: `array`, Default: `[]`)
+
+**CSS Custom Properties:**
+
+- `--fill-color-1`: Fill color for the first dataset. (Default: `color-mix(in srgb, var(--wa-color-blue-60) 40%, transparent)`)
+- `--fill-color-2`: Fill color for the second dataset. (Default: `color-mix(in srgb, var(--wa-color-pink-60) 40%, transparent)`)
+- `--fill-color-3`: Fill color for the third dataset. (Default: `color-mix(in srgb, var(--wa-color-green-60) 40%, transparent)`)
+- `--fill-color-4`: Fill color for the fourth dataset. (Default: `color-mix(in srgb, var(--wa-color-yellow-60) 40%, transparent)`)
+- `--fill-color-5`: Fill color for the fifth dataset. (Default: `color-mix(in srgb, var(--wa-color-purple-60) 40%, transparent)`)
+- `--fill-color-6`: Fill color for the sixth dataset. (Default: `color-mix(in srgb, var(--wa-color-orange-60) 40%, transparent)`)
+- `--border-color-1`: Border color for the first dataset. (Default: `var(--wa-color-blue-60)`)
+- `--border-color-2`: Border color for the second dataset. (Default: `var(--wa-color-pink-60)`)
+- `--border-color-3`: Border color for the third dataset. (Default: `var(--wa-color-green-60)`)
+- `--border-color-4`: Border color for the fourth dataset. (Default: `var(--wa-color-yellow-60)`)
+- `--border-color-5`: Border color for the fifth dataset. (Default: `var(--wa-color-purple-60)`)
+- `--border-color-6`: Border color for the sixth dataset. (Default: `var(--wa-color-orange-60)`)
+- `--grid-color`: Color of the chart grid lines and axis borders. (Default: `var(--wa-color-neutral-border-quiet)`)
+- `--border-width`: Border width for bars and arcs. (Default: `var(--wa-border-width-s)`)
+- `--border-radius`: Border radius for bar charts. (Default: `var(--wa-border-radius-s)`)
+- `--grid-border-width`: Border width for chart grid lines and axis borders. (Default: `var(--wa-border-width-s)`)
+- `--line-border-width`: Border width for line and radar charts. (Default: `var(--wa-border-width-m)`)
+- `--point-radius`: Radius of data point dots. (Default: `var(--wa-border-width-m)`)
+
+#### `<wa-radio>`
+
+**Description:** Radios represent a single option within a mutually exclusive set. Use them inside a radio group when users must pick exactly one choice from a small list.
+
+**Documentation:** https://webawesome.com/docs/components/radio
+
+**Slots:**
+
+- `(default)`: The radio's label.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[formControlStyles, sizeStyles, styles]`)
+- `value`: The radio's value. When selected, the radio group will receive this value. (Type: `string`)
+- `appearance`: The radio's visual appearance. (Type: `'default' | 'button'`, Default: `'default'`)
+- `size`: The radio's size. When used inside a radio group, the size will be determined by the radio group's size, which will override this attribute. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`)
+- `disabled`: Disables the radio. (Type: `boolean`, Default: `false`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `name`: The name of the input, submitted as a name/value pair with form data. (Type: `string | null`, Default: `null`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+- `validationTarget`: Override this to change where constraint validation popups are anchored. (Type: `undefined | HTMLElement`)
+
+**Methods:**
+
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `blur`: Emitted when the control loses focus.
+- `focus`: Emitted when the control gains focus.
+
+**CSS Custom Properties:**
+
+- `--checked-icon-color`: The color of the checked icon.
+- `--checked-icon-scale`: The size of the checked icon relative to the radio.
+
+**CSS Parts:**
+
+- `control`: The circular container that wraps the radio's checked state.
+- `checked-icon`: The checked icon.
+- `label`: The container that wraps the radio's label.
+
+**CSS States:**
+
+- `checked`: Applied when the control is checked.
+- `disabled`: Applied when the control is disabled.
+
+#### `<wa-radio-group>`
+
+**Description:** Radio groups wrap a set of radios so they function as a single form control with one shared value. They handle keyboard navigation, labeling, and validation for the group as a whole.
+
+**Documentation:** https://webawesome.com/docs/components/radio-group
+
+**Slots:**
+
+- `(default)`: The default slot where `<wa-radio>` elements are placed.
+- `label`: The radio group's label. Required for proper accessibility. Alternatively, you can use the `label` attribute.
+- `hint`: Text that describes how to use the radio group. Alternatively, you can use the `hint` attribute.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[sizeStyles, formControlStyles, styles]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `label`: The radio group's label. Required for proper accessibility. If you need to display HTML, use the `label` slot instead. (Type: `string`, Default: `''`)
+- `hint`: The radio groups's hint. If you need to display HTML, use the `hint` slot instead. (Type: `string`, Default: `''`)
+- `name`: The name of the radio group, submitted as a name/value pair with form data. (Type: `string | null`, Default: `null`)
+- `disabled`: Disables the radio group and all child radios. (Type: `boolean`, Default: `false`)
+- `orientation`: The orientation in which to show radio items. (Type: `'horizontal' | 'vertical'`, Default: `'vertical'`)
+- `value`: The current value of the radio group, submitted as a name/value pair with form data.
+- `defaultValue` (attribute: `value`): The default value of the form control. Primarily used for resetting the form control. (Type: `string | null`)
+- `size`: The radio group's size. When present, this size will be applied to all `<wa-radio>` items inside. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`)
+- `required`: Ensures a child radio is checked before allowing the containing form to submit. (Type: `boolean`, Default: `false`)
+- `withLabel` (attribute: `with-label`): Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup includes the label before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withHint` (attribute: `with-hint`): Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup includes the hint before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `validationTarget`: We use the first available radio as the validationTarget similar to native HTML that shows the validation popup on the first radio element. (Type: `undefined | HTMLElement`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+
+**Methods:**
+
+- `focus(options: FocusOptions)`: Sets focus on the radio group.
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `input`: Emitted when the radio group receives user input.
+- `change`: Emitted when the radio group's selected value changes.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Parts:**
+
+- `form-control`: The form control that wraps the label, input, and hint.
+- `form-control-label`: The label's wrapper.
+- `form-control-input`: The input's wrapper.
+- `radios`: The wrapper than surrounds radio items, styled as a flex container by default.
+- `hint`: The hint's wrapper.
+
+#### `<wa-rating>`
+
+**Description:** Ratings display a numeric score as a row of selectable symbols, typically stars. Use them to capture quick feedback or show an average rating for a product or piece of content.
+
+**Documentation:** https://webawesome.com/docs/components/rating
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[sizeStyles, styles]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `name`: The name of the rating, submitted as a name/value pair with form data. (Type: `string | null`, Default: `null`)
+- `label`: A label that describes the rating to assistive devices. (Type: `string`, Default: `''`)
+- `value`: The current rating. (Type: `number`, Default: `0`)
+- `defaultValue` (attribute: `default-value`): The default value of the form control. Used to reset the rating to its initial value. (Type: `number`, Default: `0`)
+- `max`: The highest rating to show. (Type: `number`, Default: `5`)
+- `precision`: The precision at which the rating will increase and decrease. For example, to allow half-star ratings, set this attribute to `0.5`. (Type: `number`, Default: `1`)
+- `readonly`: Makes the rating readonly. (Type: `boolean`, Default: `false`)
+- `disabled`: Disables the rating. (Type: `boolean`, Default: `false`)
+- `required`: Makes the rating a required field. (Type: `boolean`, Default: `false`)
+- `getSymbol`: A function that customizes the symbol to be rendered. The first and only argument is the rating's current value. The function should return a string containing trusted HTML of the symbol to render at the specified value. Works well with `<wa-icon>` elements. (Type: `(value: number, isSelected: boolean) => string`)
+- `size`: The component's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+- `validationTarget`: Override this to change where constraint validation popups are anchored. (Type: `undefined | HTMLElement`)
+
+**Methods:**
+
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `change`: Emitted when the rating's value changes.
+- `wa-hover`: Emitted when the user hovers over a value. The `phase` property indicates when hovering starts, moves to a new value, or ends. The `value` property tells what the rating's value would be if the user were to commit to the hovered value.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Custom Properties:**
+
+- `--symbol-color`: The inactive color for symbols.
+- `--symbol-color-active`: The active color for symbols.
+- `--symbol-spacing`: The spacing to use around symbols.
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+
+#### `<wa-relative-time>`
+
+**Description:** Relative times display a date as a localized phrase relative to now, such as "3 hours ago" or "in 2 days". The phrase updates automatically as time passes and respects the user's locale.
+
+**Documentation:** https://webawesome.com/docs/components/relative-time
+
+**Properties:**
+
+- `date`: The date from which to calculate time from. If not set, the current date and time will be used. When passing a string, it's strongly recommended to use the ISO 8601 format to ensure timezones are handled correctly. To convert a date to this format in JavaScript, use [`date.toISOString()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString). (Type: `Date | string`, Default: `new Date()`)
+- `format`: The formatting style to use. (Type: `'long' | 'short' | 'narrow'`, Default: `'long'`)
+- `numeric`: When `auto`, values such as "yesterday" and "tomorrow" will be shown when possible. When `always`, values such as "1 day ago" and "in 1 day" will be shown. (Type: `'always' | 'auto'`, Default: `'auto'`)
+- `sync`: Keep the displayed value up to date as time passes. (Type: `boolean`, Default: `false`)
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`)
+
+#### `<wa-resize-observer>`
+
+**Description:** Resize observers watch their slotted elements for size changes and emit an event when they occur. Provides a thin, declarative interface to the browser's ResizeObserver API.
+
+**Documentation:** https://webawesome.com/docs/components/resize-observer
+
+**Slots:**
+
+- `(default)`: One or more elements to watch for resizing.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `disabled`: Disables the observer. (Type: `boolean`, Default: `false`)
+
+**Events:**
+
+- `wa-resize`: Emitted when the element is resized.
+
+#### `<wa-scatter-chart>`
+
+**Description:** Scatter charts reveal relationships between two variables by plotting data points on a grid. They are ideal for identifying correlations, clusters, and outliers in datasets.
+
+**Documentation:** https://webawesome.com/docs/components/scatter-chart
+
+**Slots:**
+
+- `(default)`: An optional `<script type="application/json">` element containing the Chart.js configuration object.
+
+**Properties:**
+
+- `type`: The type of chart to render. Valid types include `bar`, `line`, `pie`, `doughnut`, `polarArea`, `radar`, `scatter`, and `bubble`. (Type: `ChartType`, Default: `'scatter'`)
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles]`)
+- `label`: A label for the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `description`: A description of the chart, used for accessibility. (Type: `string | null`, Default: `null`)
+- `xLabel`: A label for the x-axis. (Type: `string | null`, Default: `null`)
+- `yLabel`: A label for the y-axis. (Type: `string | null`, Default: `null`)
+- `legendPosition` (attribute: `legend-position`): The position of the legend relative to the chart. (Type: `LayoutPosition | 'start' | 'end'`, Default: `'top'`)
+- `stacked`: Stacks datasets on top of each other along the value axis. (Type: `boolean`, Default: `false`)
+- `indexAxis` (attribute: `index-axis`): The base axis of the dataset. 'x' for vertical bars and 'y' for horizontal bars. (Type: `'x' | 'y'`, Default: `'x'`)
+- `grid`: Which axes to show grid lines on. (Type: `'x' | 'y' | 'both' | 'none'`, Default: `'both'`)
+- `min`: The minimum value for the value axis. (Type: `number | null`, Default: `null`)
+- `max`: The maximum value for the value axis. (Type: `number | null`, Default: `null`)
+- `withoutAnimation` (attribute: `without-animation`): Disables chart animations (Type: `boolean`, Default: `false`)
+- `withoutLegend` (attribute: `without-legend`): Hides the legend (Type: `boolean`, Default: `false`)
+- `withoutTooltip` (attribute: `without-tooltip`): Hides tooltips over data points (Type: `boolean`, Default: `false`)
+- `config`: The Chart.js configuration object. Setting this property will automatically re-render the chart. (Type: `ChartJS['config']`)
+- `plugins`: Additional Chart.js plugins to register for this chart instance. (Type: `array`, Default: `[]`)
+
+**CSS Custom Properties:**
+
+- `--fill-color-1`: Fill color for the first dataset. (Default: `color-mix(in srgb, var(--wa-color-blue-60) 40%, transparent)`)
+- `--fill-color-2`: Fill color for the second dataset. (Default: `color-mix(in srgb, var(--wa-color-pink-60) 40%, transparent)`)
+- `--fill-color-3`: Fill color for the third dataset. (Default: `color-mix(in srgb, var(--wa-color-green-60) 40%, transparent)`)
+- `--fill-color-4`: Fill color for the fourth dataset. (Default: `color-mix(in srgb, var(--wa-color-yellow-60) 40%, transparent)`)
+- `--fill-color-5`: Fill color for the fifth dataset. (Default: `color-mix(in srgb, var(--wa-color-purple-60) 40%, transparent)`)
+- `--fill-color-6`: Fill color for the sixth dataset. (Default: `color-mix(in srgb, var(--wa-color-orange-60) 40%, transparent)`)
+- `--border-color-1`: Border color for the first dataset. (Default: `var(--wa-color-blue-60)`)
+- `--border-color-2`: Border color for the second dataset. (Default: `var(--wa-color-pink-60)`)
+- `--border-color-3`: Border color for the third dataset. (Default: `var(--wa-color-green-60)`)
+- `--border-color-4`: Border color for the fourth dataset. (Default: `var(--wa-color-yellow-60)`)
+- `--border-color-5`: Border color for the fifth dataset. (Default: `var(--wa-color-purple-60)`)
+- `--border-color-6`: Border color for the sixth dataset. (Default: `var(--wa-color-orange-60)`)
+- `--grid-color`: Color of the chart grid lines and axis borders. (Default: `var(--wa-color-neutral-border-quiet)`)
+- `--border-width`: Border width for bars and arcs. (Default: `var(--wa-border-width-s)`)
+- `--border-radius`: Border radius for bar charts. (Default: `var(--wa-border-radius-s)`)
+- `--grid-border-width`: Border width for chart grid lines and axis borders. (Default: `var(--wa-border-width-s)`)
+- `--line-border-width`: Border width for line and radar charts. (Default: `var(--wa-border-width-m)`)
+- `--point-radius`: Radius of data point dots. (Default: `var(--wa-border-width-m)`)
+
+#### `<wa-scroller>`
+
+**Description:** Scrollers wrap overflowing content in an accessible container with visual cues that help users recognize and navigate scrollable regions.
+
+**Documentation:** https://webawesome.com/docs/components/scroller
+
+**Slots:**
+
+- `(default)`: The content to show inside the scroller.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles]`)
+- `orientation`: The scroller's orientation. (Type: `'horizontal' | 'vertical'`, Default: `'horizontal'`)
+- `withoutScrollbar` (attribute: `without-scrollbar`): Removes the visible scrollbar. (Type: `boolean`, Default: `false`)
+- `withoutShadow` (attribute: `without-shadow`): Removes the shadows. (Type: `boolean`, Default: `false`)
+
+**CSS Custom Properties:**
+
+- `--shadow-color`: The base color of the shadow. (Default: `var(--wa-color-surface-default)`)
+- `--shadow-size`: The size of the shadow. (Default: `2rem`)
+
+**CSS Parts:**
+
+- `content`: The container that wraps the slotted content.
+
+#### `<wa-select>`
+
+**Description:** Selects let users choose one or more values from a dropdown list of predefined options. Use them in forms when a fixed set of choices needs to fit in limited space.
+
+**Documentation:** https://webawesome.com/docs/components/select
+
+**Slots:**
+
+- `(default)`: The listbox options. Must be `<wa-option>` elements. You can use `<wa-divider>` to group items visually.
+- `label`: The input's label. Alternatively, you can use the `label` attribute.
+- `start`: An element, such as `<wa-icon>`, placed at the start of the combobox.
+- `end`: An element, such as `<wa-icon>`, placed at the end of the combobox.
+- `clear-icon`: An icon to use in lieu of the default clear icon.
+- `expand-icon`: The icon to show when the control is expanded and collapsed. Rotates on open and close.
+- `hint`: Text that describes how to use the input. Alternatively, you can use the `hint` attribute.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles, formControlStyles, sizeStyles]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `validationTarget`: Where to anchor native constraint validation (Type: `undefined | HTMLElement`)
+- `name`: The name of the select, submitted as a name/value pair with form data. (Type: `string | null`, Default: `''`)
+- `value`: The select's value. This will be a string for single select or an array for multi-select.
+- `size`: The select's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `placeholder`: Placeholder text to show as a hint when the select is empty. (Type: `string`, Default: `''`)
+- `multiple`: Allows more than one option to be selected. (Type: `boolean`, Default: `false`)
+- `maxOptionsVisible` (attribute: `max-options-visible`): The maximum number of selected options to show when `multiple` is true. After the maximum, "+n" will be shown to indicate the number of additional items that are selected. Set to 0 to remove the limit. (Type: `number`, Default: `3`)
+- `disabled`: Disables the select control. (Type: `boolean`, Default: `false`)
+- `withClear` (attribute: `with-clear`): Adds a clear button when the select is not empty. (Type: `boolean`, Default: `false`)
+- `open`: Indicates whether or not the select is open. You can toggle this attribute to show and hide the menu, or you can use the `show()` and `hide()` methods and this attribute will reflect the select's open state. (Type: `boolean`, Default: `false`)
+- `appearance`: The select's visual appearance. (Type: `'filled' | 'outlined' | 'filled-outlined'`, Default: `'outlined'`)
+- `pill`: Draws a pill-style select with rounded edges. (Type: `boolean`, Default: `false`)
+- `label`: The select's label. If you need to display HTML, use the `label` slot instead. (Type: `string`, Default: `''`)
+- `placement`: The preferred placement of the select's menu. Note that the actual placement may vary as needed to keep the listbox inside of the viewport. (Type: `'top' | 'bottom'`, Default: `'bottom'`)
+- `hint`: The select's hint. If you need to display HTML, use the `hint` slot instead. (Type: `string`, Default: `''`)
+- `withLabel` (attribute: `with-label`): Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup includes the label before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withHint` (attribute: `with-hint`): Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup includes the hint before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `required`: The select's required attribute. (Type: `boolean`, Default: `false`)
+- `getTag`: A function that customizes the tags to be rendered when multiple=true. The first argument is the option, the second is the current tag's index.  The function should return either a Lit TemplateResult or a string containing trusted HTML of the symbol to render at the specified value. (Type: `(option: WaOption, index: number) => TemplateResult | string | HTMLElement`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+
+**Methods:**
+
+- `show()`: Shows the listbox.
+- `hide()`: Hides the listbox.
+- `focus(options: FocusOptions)`: Sets focus on the control.
+- `blur()`: Removes focus from the control.
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `input`: Emitted when the control receives input.
+- `change`: Emitted when the control's value changes.
+- `focus`: Emitted when the control gains focus.
+- `blur`: Emitted when the control loses focus.
+- `wa-clear`: Emitted when the control's value is cleared.
+- `wa-show`: Emitted when the select's menu opens.
+- `wa-after-show`: Emitted after the select's menu opens and all animations are complete.
+- `wa-hide`: Emitted when the select's menu closes.
+- `wa-after-hide`: Emitted after the select's menu closes and all animations are complete.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Custom Properties:**
+
+- `--show-duration`: The duration of the show animation. (Default: `100ms`)
+- `--hide-duration`: The duration of the hide animation. (Default: `100ms`)
+- `--tag-max-size`: When using `multiple`, the max size of tags before their content is truncated. (Default: `10ch`)
+
+**CSS Parts:**
+
+- `form-control`: The form control that wraps the label, input, and hint.
+- `form-control-label`: The label's wrapper.
+- `form-control-input`: The select's wrapper.
+- `hint`: The hint's wrapper.
+- `combobox`: The container the wraps the start, end, value, clear icon, and expand button.
+- `start`: The container that wraps the `start` slot.
+- `end`: The container that wraps the `end` slot.
+- `display-input`: The element that displays the selected option's label, an `<input>` element.
+- `listbox`: The listbox container where options are slotted.
+- `tags`: The container that houses option tags when `multiselect` is used.
+- `tag`: The individual tags that represent each multiselect option.
+- `tag__content`: The tag's content part.
+- `tag__remove-button`: The tag's remove button.
+- `tag__remove-button__base`: The tag's remove button base part.
+- `clear-button`: The clear button.
+- `expand-icon`: The container that wraps the expand icon.
+
+**CSS States:**
+
+- `blank`: The select is empty.
+
+#### `<wa-skeleton>`
+
+**Description:** Skeletons show placeholder shapes where content will appear once it finishes loading, reducing perceived wait time and preventing layout shift.
+
+**Documentation:** https://webawesome.com/docs/components/skeleton
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `effect`: Determines which effect the skeleton will use. (Type: `'pulse' | 'sheen' | 'none'`, Default: `'none'`)
+
+**CSS Custom Properties:**
+
+- `--color`: The color of the skeleton.
+- `--sheen-color`: The sheen color when the skeleton is in its loading state.
+
+**CSS Parts:**
+
+- `indicator`: The skeleton's indicator which is responsible for its color and animation.
+
+#### `<wa-slider>`
+
+**Description:** Sliders let users choose a numeric value within a defined range by dragging a thumb along a track.
+
+**Documentation:** https://webawesome.com/docs/components/slider
+
+**Slots:**
+
+- `label`: The slider label. Alternatively, you can use the `label` attribute.
+- `hint`: Text that describes how to use the input. Alternatively, you can use the `hint` attribute. instead.
+- `reference`: One or more reference labels to show visually below the slider.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[sizeStyles, formControlStyles, styles]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `validationTarget`: Override validation target to point to the focusable element (Type: `undefined | HTMLElement`)
+- `label`: The slider's label. If you need to provide HTML in the label, use the `label` slot instead. (Type: `string`, Default: `''`)
+- `hint`: The slider hint. If you need to display HTML, use the hint slot instead. (Type: `string`, Default: `''`)
+- `name`: The name of the slider. This will be submitted with the form as a name/value pair. (Type: `string | null`, Default: `null`)
+- `minValue` (attribute: `min-value`): The minimum value of a range selection. Used only when range attribute is set. (Type: `number`, Default: `0`)
+- `maxValue` (attribute: `max-value`): The maximum value of a range selection. Used only when range attribute is set. (Type: `number`, Default: `50`)
+- `defaultValue` (attribute: `value`): The default value of the form control. Primarily used for resetting the form control. (Type: `number`)
+- `value`: The current value of the slider, submitted as a name/value pair with form data. (Type: `number`)
+- `range`: Converts the slider to a range slider with two thumbs. (Type: `boolean`, Default: `false`)
+- `isRange`: Get if this is a range slider (Type: `boolean`)
+- `disabled`: Disables the slider. (Type: `boolean`, Default: `false`)
+- `readonly`: Makes the slider a read-only field. (Type: `boolean`, Default: `false`)
+- `orientation`: The orientation of the slider. (Type: `'horizontal' | 'vertical'`, Default: `'horizontal'`)
+- `size`: The slider's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `indicatorOffset` (attribute: `indicator-offset`): The starting value from which to draw the slider's fill, which is based on its current value. (Type: `number`)
+- `min`: The minimum value allowed. (Type: `number`, Default: `0`)
+- `max`: The maximum value allowed. (Type: `number`, Default: `100`)
+- `step`: The granularity the value must adhere to when incrementing and decrementing. (Type: `number`, Default: `1`)
+- `autofocus`: Tells the browser to focus the slider when the page loads or a dialog is shown. (Type: `boolean`)
+- `tooltipDistance` (attribute: `tooltip-distance`): The distance of the tooltip from the slider's thumb. (Type: `number`, Default: `8`)
+- `tooltipPlacement` (attribute: `tooltip-placement`): The placement of the tooltip in reference to the slider's thumb. (Type: `'top' | 'right' | 'bottom' | 'left'`, Default: `'top'`)
+- `withMarkers` (attribute: `with-markers`): Draws markers at each step along the slider. (Type: `boolean`, Default: `false`)
+- `withTooltip` (attribute: `with-tooltip`): Draws a tooltip above the thumb when the control has focus or is dragged. (Type: `boolean`, Default: `false`)
+- `withLabel` (attribute: `with-label`): Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup includes the label before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withHint` (attribute: `with-hint`): Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup includes the hint before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `valueFormatter`: A custom formatting function to apply to the value. This will be shown in the tooltip and announced by screen readers. Must be set with JavaScript. Property only. (Type: `(value: number) => string`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+
+**Methods:**
+
+- `focus()`: Sets focus to the slider.
+- `blur()`: Removes focus from the slider.
+- `stepDown()`: Decreases the slider's value by `step`. This is a programmatic change, so `input` and `change` events will not be emitted when this is called.
+- `stepUp()`: Increases the slider's value by `step`. This is a programmatic change, so `input` and `change` events will not be emitted when this is called.
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `change`: Emitted when an alteration to the control's value is committed by the user.
+- `blur`: Emitted when the control loses focus.
+- `focus`: Emitted when the control gains focus.
+- `input`: Emitted when the control receives input.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Custom Properties:**
+
+- `--track-size`: The height or width of the slider's track. (Default: `0.75em`)
+- `--marker-width`: The width of each individual marker. (Default: `0.1875em`)
+- `--marker-height`: The height of each individual marker. (Default: `0.1875em`)
+- `--thumb-width`: The width of the thumb. (Default: `1.25em`)
+- `--thumb-height`: The height of the thumb. (Default: `1.25em`)
+
+**CSS Parts:**
+
+- `label`: The element that contains the sliders's label.
+- `hint`: The element that contains the slider's description.
+- `slider`: The focusable element with `role="slider"`. Contains the track and reference slot.
+- `track`: The slider's track.
+- `indicator`: The colored indicator that shows from the start of the slider to the current value.
+- `markers`: The container that holds all the markers when `with-markers` is used.
+- `marker`: The individual markers that are shown when `with-markers` is used.
+- `references`: The container that holds references that get slotted in.
+- `thumb`: The slider's thumb.
+- `thumb-min`: The min value thumb in a range slider.
+- `thumb-max`: The max value thumb in a range slider.
+- `tooltip`: The tooltip, a `<wa-tooltip>` element.
+- `tooltip__tooltip`: The tooltip's `tooltip` part.
+- `tooltip__content`: The tooltip's `content` part.
+- `tooltip__arrow`: The tooltip's `arrow` part.
+
+**CSS States:**
+
+- `disabled`: Applied when the slider is disabled.
+- `dragging`: Applied when the slider is being dragged.
+- `focused`: Applied when the slider has focus.
+- `user-valid`: Applied when the slider is valid and the user has sufficiently interacted with it.
+- `user-invalid`: Applied when the slider is invalid and the user has sufficiently interacted with it.
+
+#### `<wa-sparkline>`
+
+**Description:** Sparklines display inline data trends as compact, visual charts.
+
+**Documentation:** https://webawesome.com/docs/components/sparkline
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles]`)
+- `label`: An accessible label describing the sparkline for screen readers. (Type: `string`, Default: `''`)
+- `data`: Space-separated numeric values to visualize (e.g., "10 20 40 25 35"). (Type: `string`, Default: `''`)
+- `appearance`: The visual fill style of the sparkline. (Type: `'gradient' | 'line' | 'solid'`, Default: `'solid'`)
+- `trend`: A trend to indicate, which will affect the sparkline's default color. (Type: `'positive' | 'negative' | 'neutral'`)
+- `curve`: The type of curve used to connect data points. (Type: `'linear' | 'natural' | 'step'`, Default: `'linear'`)
+
+**CSS Custom Properties:**
+
+- `--fill-color`: The fill color for the area under the line.
+- `--line-color`: The color of the sparkline stroke.
+- `--line-width`: The width of the sparkline stroke.
+
+**CSS Parts:**
+
+- `base`: The SVG container element.
+- `line`: The sparkline stroke path.
+- `fill`: The filled area under the line (visible with gradient or solid appearance).
+
+#### `<wa-spinner>`
+
+**Description:** Spinners indicate that an operation is in progress when the duration is unknown. Use them for loading states where a determinate progress bar isn't practical.
+
+**Documentation:** https://webawesome.com/docs/components/spinner
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+
+**CSS Custom Properties:**
+
+- `--track-width`: The width of the track.
+- `--track-color`: The color of the track.
+- `--indicator-color`: The color of the spinner's indicator.
+- `--speed`: The time it takes for the spinner to complete one animation cycle.
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+
+#### `<wa-split-panel>`
+
+**Description:** Split panels display two adjacent panels separated by a draggable divider, letting users resize each side to suit their workflow.
+
+**Documentation:** https://webawesome.com/docs/components/split-panel
+
+**Slots:**
+
+- `start`: Content to place in the start panel.
+- `end`: Content to place in the end panel.
+- `divider`: The divider. Useful for slotting in a custom icon that renders as a handle.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `position`: The current position of the divider from the primary panel's edge as a percentage 0-100. Defaults to 50% of the container's initial size. (Type: `number`, Default: `50`)
+- `positionInPixels` (attribute: `position-in-pixels`): The current position of the divider from the primary panel's edge in pixels. (Type: `number`)
+- `orientation`: Sets the split panel's orientation. (Type: `'horizontal' | 'vertical'`, Default: `'horizontal'`)
+- `disabled`: Disables resizing. Note that the position may still change as a result of resizing the host element. (Type: `boolean`, Default: `false`)
+- `primary`: If no primary panel is designated, both panels will resize proportionally when the host element is resized. If a primary panel is designated, it will maintain its size and the other panel will grow or shrink as needed when the host element is resized. (Type: `'start' | 'end' | undefined`)
+- `snap`: One or more space-separated values at which the divider should snap. Values can be in pixels or percentages, e.g. `"100px 50%"`. (Type: `string | undefined`)
+- `snapThreshold` (attribute: `snap-threshold`): How close the divider must be to a snap point until snapping occurs. (Type: `number`, Default: `12`)
+
+**Events:**
+
+- `wa-reposition`: Emitted when the divider's position changes.
+
+**CSS Custom Properties:**
+
+- `--divider-width`: The width of the visible divider. (Default: `4px`)
+- `--divider-hit-area`: The invisible region around the divider where dragging can occur. This is usually wider than the divider to facilitate easier dragging. (Default: `12px`)
+- `--min`: The minimum allowed size of the primary panel. (Default: `0`)
+- `--max`: The maximum allowed size of the primary panel. (Default: `100%`)
+
+**CSS Parts:**
+
+- `start`: The start panel.
+- `end`: The end panel.
+- `panel`: Targets both the start and end panels.
+- `divider`: The divider that separates the start and end panels.
+
+#### `<wa-switch>`
+
+**Description:** Switches toggle a single setting on or off and apply the change immediately, without requiring a form submission.
+
+**Documentation:** https://webawesome.com/docs/components/switch
+
+**Slots:**
+
+- `(default)`: The switch's label.
+- `hint`: Text that describes how to use the switch. Alternatively, you can use the `hint` attribute.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[formControlStyles, sizeStyles, styles]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `name`: The name of the switch, submitted as a name/value pair with form data. (Type: `string | null`, Default: `null`)
+- `value`: The value of the switch, submitted as a name/value pair with form data. (Type: `string | null`)
+- `size`: The switch's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `disabled`: Disables the switch. (Type: `boolean`, Default: `false`)
+- `checked`: Draws the checkbox in a checked state.
+- `defaultChecked` (attribute: `checked`): The default value of the form control. Primarily used for resetting the form control. (Type: `boolean`)
+- `required`: Makes the switch a required field. (Type: `boolean`, Default: `false`)
+- `hint`: The switch's hint. If you need to display HTML, use the `hint` slot instead. (Type: `string`, Default: `''`)
+- `withHint` (attribute: `with-hint`): Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup includes the hint before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+- `validationTarget`: Override this to change where constraint validation popups are anchored. (Type: `undefined | HTMLElement`)
+
+**Methods:**
+
+- `click()`: Simulates a click on the switch.
+- `focus(options: FocusOptions)`: Sets focus on the switch.
+- `blur()`: Removes focus from the switch.
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `change`: Emitted when the control's checked state changes.
+- `input`: Emitted when the control receives input.
+- `blur`: Emitted when the control loses focus.
+- `focus`: Emitted when the control gains focus.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Custom Properties:**
+
+- `--width`: The width of the switch.
+- `--height`: The height of the switch.
+- `--thumb-size`: The size of the thumb.
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+- `control`: The control that houses the switch's thumb.
+- `thumb`: The switch's thumb.
+- `label`: The switch's label.
+- `hint`: The hint's wrapper.
+
+#### `<wa-tab>`
+
+**Description:** Tabs label and activate an individual panel inside a tab group.
+
+**Documentation:** https://webawesome.com/docs/components/tab
+
+**Slots:**
+
+- `(default)`: The tab's label.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `panel`: The name of the tab panel this tab is associated with. The panel must be located in the same tab group. (Type: `string`, Default: `''`)
+- `disabled`: Disables the tab and prevents selection. (Type: `boolean`, Default: `false`)
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+
+#### `<wa-tab-group>`
+
+**Description:** Tab groups organize related content into a single container that displays one panel at a time, with tabs for switching between them.
+
+**Documentation:** https://webawesome.com/docs/components/tab-group
+
+**Slots:**
+
+- `(default)`: Used for grouping tab panels in the tab group. Must be `<wa-tab-panel>` elements.
+- `nav`: Used for grouping tabs in the tab group. Must be `<wa-tab>` elements. Note that `<wa-tab>` will set this slot on itself automatically.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `defaultSlot`: Default slot for `<wa-tab-panel>` children (inside the `body` part container). (Type: `HTMLSlotElement`)
+- `active`: Sets the active tab. (Type: `string`, Default: `''`)
+- `placement`: The placement of the tabs. (Type: `'top' | 'bottom' | 'start' | 'end'`, Default: `'top'`)
+- `activation`: When set to auto, navigating tabs with the arrow keys will instantly show the corresponding tab panel. When set to manual, the tab will receive focus but will not show until the user presses spacebar or enter. (Type: `'auto' | 'manual'`, Default: `'auto'`)
+- `withoutScrollControls` (attribute: `without-scroll-controls`): Disables the scroll arrows that appear when tabs overflow. (Type: `boolean`, Default: `false`)
+
+**Events:**
+
+- `wa-tab-show`: Emitted when a tab is shown.
+- `wa-tab-hide`: Emitted when a tab is hidden.
+
+**CSS Custom Properties:**
+
+- `--indicator-color`: The color of the active tab indicator.
+- `--track-color`: The color of the indicator's track (the line that separates tabs from panels).
+- `--track-width`: The width of the indicator's track (the line that separates tabs from panels).
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+- `nav`: The tab group's navigation container where tabs are slotted in.
+- `tabs`: The container that wraps the tabs.
+- `body`: The tab group's body where tab panels are slotted in.
+- `scroll-button`: The previous/next scroll buttons that show when tabs are scrollable, a `<wa-button>`.
+- `scroll-button-start`: The starting scroll button.
+- `scroll-button-end`: The ending scroll button.
+- `scroll-button__base`: The scroll button's exported `base` part.
+
+#### `<wa-tab-panel>`
+
+**Description:** Tab panels hold the content shown for a single tab inside a tab group.
+
+**Documentation:** https://webawesome.com/docs/components/tab-panel
+
+**Slots:**
+
+- `(default)`: The tab panel's content.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `name`: The tab panel's name. (Type: `string`, Default: `''`)
+- `active`: When true, the tab panel will be shown. (Type: `boolean`, Default: `false`)
+
+**CSS Custom Properties:**
+
+- `--padding`: The tab panel's padding.
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+
+#### `<wa-tag>`
+
+**Description:** Tags label, categorize, or represent selections with a compact visual marker. Use them for status indicators, filters, or removable chips.
+
+**Documentation:** https://webawesome.com/docs/components/tag
+
+**Slots:**
+
+- `(default)`: The tag's content.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles, variantStyles, sizeStyles]`)
+- `variant`: The tag's theme variant. Defaults to `neutral` if not within another element with a variant. (Type: `'brand' | 'neutral' | 'success' | 'warning' | 'danger'`, Default: `'neutral'`)
+- `appearance`: The tag's visual appearance. (Type: `'accent' | 'filled' | 'outlined' | 'filled-outlined'`, Default: `'filled-outlined'`)
+- `size`: The tag's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `pill`: Draws a pill-style tag with rounded edges. (Type: `boolean`, Default: `false`)
+- `withRemove` (attribute: `with-remove`): Makes the tag removable and shows a remove button. (Type: `boolean`, Default: `false`)
+
+**Events:**
+
+- `wa-remove`: Emitted when the remove button is activated.
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+- `content`: The tag's content.
+- `remove-button`: The tag's remove button, a `<wa-button>`.
+- `remove-button__base`: The remove button's exported `base` part.
+
+#### `<wa-textarea>`
+
+**Description:** Textareas collect multi-line text input from the user, with optional resizing and character counting.
+
+**Documentation:** https://webawesome.com/docs/components/textarea
+
+**Slots:**
+
+- `label`: The textarea's label. Alternatively, you can use the `label` attribute.
+- `hint`: Text that describes how to use the input. Alternatively, you can use the `hint` attribute.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles, formControlStyles, sizeStyles, visuallyHidden]`)
+- `validators`: Validators are static because they have `observedAttributes`, essentially attributes to "watch" for changes. Whenever these attributes change, we want to be notified and update the validator. (Type: `Validator[]`, Default: `[]`)
+- `name`: The name of the textarea, submitted as a name/value pair with form data. (Type: `string | null`, Default: `null`)
+- `value`: The current value of the input, submitted as a name/value pair with form data.
+- `defaultValue` (attribute: `value`): The default value of the form control. Primarily used for resetting the form control. (Type: `string`)
+- `size`: The textarea's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `appearance`: The textarea's visual appearance. (Type: `'filled' | 'outlined' | 'filled-outlined'`, Default: `'outlined'`)
+- `label`: The textarea's label. If you need to display HTML, use the `label` slot instead. (Type: `string`, Default: `''`)
+- `hint`: The textarea's hint. If you need to display HTML, use the `hint` slot instead. (Type: `string`, Default: `''`)
+- `placeholder`: Placeholder text to show as a hint when the input is empty. (Type: `string`, Default: `''`)
+- `rows`: The number of rows to display by default. (Type: `number`, Default: `4`)
+- `resize`: Controls how the textarea can be resized. (Type: `'none' | 'vertical' | 'horizontal' | 'both' | 'auto'`, Default: `'vertical'`)
+- `disabled`: Disables the textarea. (Type: `boolean`, Default: `false`)
+- `readonly`: Makes the textarea readonly. (Type: `boolean`, Default: `false`)
+- `required`: Makes the textarea a required field. (Type: `boolean`, Default: `false`)
+- `minlength`: The minimum length of input that will be considered valid. (Type: `number`)
+- `maxlength`: The maximum length of input that will be considered valid. (Type: `number`)
+- `autocapitalize`: Controls whether and how text input is automatically capitalized as it is entered by the user. (Type: `'off' | 'none' | 'on' | 'sentences' | 'words' | 'characters'`)
+- `autocorrect`: Indicates whether the browser's autocorrect feature is on or off. When set as an attribute, use `"off"` or `"on"`. When set as a property, use `true` or `false`. (Type: `boolean`)
+- `autocomplete`: Specifies what permission the browser has to provide assistance in filling out form field values. Refer to [this page on MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/autocomplete) for available values. (Type: `string`)
+- `autofocus`: Indicates that the input should receive focus on page load. (Type: `boolean`)
+- `enterkeyhint`: Used to customize the label or icon of the Enter key on virtual keyboards. (Type: `'enter' | 'done' | 'go' | 'next' | 'previous' | 'search' | 'send'`)
+- `spellcheck`: Enables spell checking on the textarea. (Type: `boolean`, Default: `true`)
+- `inputmode`: Tells the browser what type of data will be entered by the user, allowing it to display the appropriate virtual keyboard on supportive devices. (Type: `'none' | 'text' | 'decimal' | 'numeric' | 'tel' | 'search' | 'email' | 'url'`)
+- `withLabel` (attribute: `with-label`): Only required for SSR. Set to `true` if you're slotting in a `label` element so the server-rendered markup includes the label before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withHint` (attribute: `with-hint`): Only required for SSR. Set to `true` if you're slotting in a `hint` element so the server-rendered markup includes the hint before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+- `withCount` (attribute: `with-count`): Shows a character count below the textarea. When `maxlength` is set, shows remaining characters instead. (Type: `boolean`, Default: `false`)
+- `form`: By default, form controls are associated with the nearest containing `<form>` element. This attribute allows you to place the form control outside of a form and associate it with the form that has this `id`. The form must be in the same document or shadow root for this to work. (Type: `HTMLFormElement | null`)
+- `validationTarget`: Override this to change where constraint validation popups are anchored. (Type: `undefined | HTMLElement`)
+
+**Methods:**
+
+- `focus(options: FocusOptions)`: Sets focus on the textarea.
+- `blur()`: Removes focus from the textarea.
+- `select()`: Selects all the text in the textarea.
+- `scrollPosition(position: { top?: number; left?: number })`: Gets or sets the textarea's scroll position.
+- `setSelectionRange(selectionStart: number, selectionEnd: number, selectionDirection: 'forward' | 'backward' | 'none')`: Sets the start and end positions of the text selection (0-based).
+- `setRangeText(replacement: string, start: number, end: number, selectMode: 'select' | 'start' | 'end' | 'preserve')`: Replaces a range of text with a new string.
+- `setCustomValidity(message: string)`: Do not use this when creating a "Validator". This is intended for end users of components. We track manually defined custom errors so we don't clear them on accident in our validators.
+- `formStateRestoreCallback(state: string | File | FormData | null, reason: 'autocomplete' | 'restore')`: Called when the browser is trying to restore element’s state to state in which case reason is "restore", or when the browser is trying to fulfill autofill on behalf of user in which case reason is "autocomplete". In the case of "restore", state is a string, File, or FormData object previously set as the second argument to setFormValue.
+- `resetValidity()`: Reset validity is a way of removing manual custom errors and native validation.
+
+**Events:**
+
+- `blur`: Emitted when the control loses focus.
+- `change`: Emitted when an alteration to the control's value is committed by the user.
+- `focus`: Emitted when the control gains focus.
+- `input`: Emitted when the control receives input.
+- `wa-invalid`: Emitted when the form control has been checked for validity and its constraints aren't satisfied.
+
+**CSS Parts:**
+
+- `label`: The label
+- `form-control-input`: The input's wrapper.
+- `hint`: The hint's wrapper.
+- `textarea`: The internal `<textarea>` control.
+- `base`: The wrapper around the `<textarea>` control.
+- `count`: The character count element, rendered when the `with-count` attribute is present.
+
+**CSS States:**
+
+- `blank`: The textarea is empty.
+
+#### `<wa-toast>`
+
+**Description:** Toasts display brief, non-blocking notifications that appear temporarily above the page content.
+
+**Documentation:** https://webawesome.com/docs/components/toast
+
+**Slots:**
+
+- `(default)`: Place `<wa-toast-item>` elements here to show them as notifications.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `placement`: The placement of the toast stack on the screen. (Type: `| 'top-start'     | 'top-center'     | 'top-end'     | 'bottom-start'     | 'bottom-center'     | 'bottom-end'`, Default: `'top-end'`)
+
+**Methods:**
+
+- `create(message: string, options: ToastCreateOptions)`: Creates a toast notification programmatically and adds it to the stack. Returns a reference to the created toast item element.
+
+**CSS Custom Properties:**
+
+- `--gap`: The gap between stacked toast items. (Default: `var(--wa-space-s)`)
+- `--width`: The width of the toast stack. (Default: `28rem`)
+
+**CSS Parts:**
+
+- `stack`: The container that holds the toast items.
+
+**CSS States:**
+
+- `visible`: Applied when the toast stack has one or more visible toast items.
+
+#### `<wa-toast-item>`
+
+**Description:** Toast items are individual notifications displayed within a toast container.
+
+**Documentation:** https://webawesome.com/docs/components/toast-item
+
+**Slots:**
+
+- `(default)`: The toast item's message content.
+- `icon`: An optional icon to show at the start of the toast item.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `[styles, variantStyles, sizeStyles]`)
+- `variant`: The toast item's variant. (Type: `'brand' | 'success' | 'warning' | 'danger' | 'neutral'`, Default: `'neutral'`)
+- `size`: The toast item's size. (Type: `'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large'`, Default: `'m'`)
+- `duration`: The length of time in milliseconds before the toast item is automatically dismissed. Set to 0 to keep the toast item open until the user dismisses it. (Type: `number`, Default: `5000`)
+- `withIcon` (attribute: `with-icon`): Only required for SSR. Set to `true` if you're slotting in an `icon` element so the server-rendered markup includes the icon before the component hydrates on the client. (Type: `boolean`, Default: `false`)
+
+**Methods:**
+
+- `hide()`: Hides the toast item with animation and removes it from the DOM.
+
+**Events:**
+
+- `wa-show`: Emitted when the toast item begins to show.
+- `wa-after-show`: Emitted after the toast item has finished showing.
+- `wa-hide`: Emitted when the toast item begins to hide.
+- `wa-after-hide`: Emitted after the toast item has finished hiding.
+
+**CSS Custom Properties:**
+
+- `--accent-width`: The width of the accent line. Defaults to 4px.
+- `--show-duration`: The animation duration when showing. Defaults to 200ms.
+- `--hide-duration`: The animation duration when hiding. Defaults to 200ms.
+
+**CSS Parts:**
+
+- `toast-item`: The toast item's main container.
+- `accent`: The colored accent line on the start side.
+- `icon`: The icon container.
+- `content`: The message content container.
+- `close-button`: The close button element.
+- `progress-ring`: The progress ring component.
+- `progress-ring__base`: The progress ring's exported base part.
+- `progress-ring__label`: The progress ring's exported label part.
+- `progress-ring__track`: The progress ring's exported track part.
+- `progress-ring__indicator`: The progress ring's exported indicator part.
+- `close-icon`: The close icon element.
+- `close-icon__svg`: The close icon's exported svg part.
+
+#### `<wa-tooltip>`
+
+**Description:** Tooltips display brief contextual information when the user hovers, focuses, or taps a target element.
+
+**Documentation:** https://webawesome.com/docs/components/tooltip
+
+**Slots:**
+
+- `(default)`: The tooltip's default slot where any content should live. Interactive content should be avoided.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `placement`: The preferred placement of the tooltip. Note that the actual placement may vary as needed to keep the tooltip inside of the viewport. (Type: `| 'top'     | 'top-start'     | 'top-end'     | 'right'     | 'right-start'     | 'right-end'     | 'bottom'     | 'bottom-start'     | 'bottom-end'     | 'left'     | 'left-start'     | 'left-end'`, Default: `'top'`)
+- `disabled`: Disables the tooltip so it won't show when triggered. (Type: `boolean`, Default: `false`)
+- `distance`: The distance in pixels from which to offset the tooltip away from its target. (Type: `number`, Default: `8`)
+- `open`: Indicates whether or not the tooltip is open. You can use this in lieu of the show/hide methods. (Type: `boolean`, Default: `false`)
+- `skidding`: The distance in pixels from which to offset the tooltip along its target. (Type: `number`, Default: `0`)
+- `showDelay` (attribute: `show-delay`): The amount of time to wait before showing the tooltip when the user mouses in. (Type: `number`, Default: `150`)
+- `hideDelay` (attribute: `hide-delay`): The amount of time to wait before hiding the tooltip when the user mouses out. (Type: `number`, Default: `0`)
+- `trigger`: Controls how the tooltip is activated. Possible options include `click`, `hover`, `focus`, and `manual`. Multiple options can be passed by separating them with a space. When manual is used, the tooltip must be activated programmatically. (Type: `string`, Default: `'hover focus'`)
+- `withoutArrow` (attribute: `without-arrow`): Removes the arrow from the tooltip. (Type: `boolean`, Default: `false`)
+
+**Methods:**
+
+- `show()`: Shows the tooltip.
+- `hide()`: Hides the tooltip
+
+**Events:**
+
+- `wa-show`: Emitted when the tooltip begins to show.
+- `wa-after-show`: Emitted after the tooltip has shown and all animations are complete.
+- `wa-hide`: Emitted when the tooltip begins to hide.
+- `wa-after-hide`: Emitted after the tooltip has hidden and all animations are complete.
+
+**CSS Custom Properties:**
+
+- `--max-width`: The maximum width of the tooltip before its content will wrap.
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper, an `<wa-popup>` element.
+- `base__popup`: The popup's exported `popup` part. Use this to target the tooltip's popup container.
+- `base__arrow`: The popup's exported `arrow` part. Use this to target the tooltip's arrow.
+- `body`: The tooltip's body where its content is rendered.
+
+#### `<wa-tree>`
+
+**Description:** Trees allow you to display a hierarchical list of selectable tree items. Items with children can be expanded and collapsed as desired by the user.
+
+**Documentation:** https://webawesome.com/docs/components/tree
+
+**Slots:**
+
+- `(default)`: The default slot.
+- `expand-icon`: The icon to show when the tree item is expanded. Works best with `<wa-icon>`.
+- `collapse-icon`: The icon to show when the tree item is collapsed. Works best with `<wa-icon>`.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `selection`: The selection behavior of the tree. Single selection allows only one node to be selected at a time. Multiple displays checkboxes and allows more than one node to be selected. Leaf allows only leaf nodes to be selected. (Type: `'single' | 'multiple' | 'leaf'`, Default: `'single'`)
+
+**Events:**
+
+- `wa-selection-change`: Emitted when a tree item is selected or deselected.
+
+**CSS Custom Properties:**
+
+- `--indent-size`: The size of the indentation for nested items. (Default: `var(--wa-space-m)`)
+- `--indent-guide-color`: The color of the indentation line. (Default: `var(--wa-color-surface-border)`)
+- `--indent-guide-offset`: The amount of vertical spacing to leave between the top and bottom of the indentation line's starting position. (Default: `0`)
+- `--indent-guide-style`: The style of the indentation line, e.g. solid, dotted, dashed. (Default: `solid`)
+- `--indent-guide-width`: The width of the indentation line. (Default: `0`)
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+
+#### `<wa-tree-item>`
+
+**Description:** Tree items represent a single hierarchical node inside a tree, and can contain nested items that expand and collapse.
+
+**Documentation:** https://webawesome.com/docs/components/tree-item
+
+**Slots:**
+
+- `(default)`: The default slot.
+- `expand-icon`: The icon to show when the tree item is expanded.
+- `collapse-icon`: The icon to show when the tree item is collapsed.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `expanded`: Expands the tree item. (Type: `boolean`, Default: `false`)
+- `selected`: Draws the tree item in a selected state. (Type: `boolean`, Default: `false`)
+- `disabled`: Disables the tree item. (Type: `boolean`, Default: `false`)
+- `lazy`: Enables lazy loading behavior. (Type: `boolean`, Default: `false`)
+
+**Methods:**
+
+- `getChildrenItems({ includeDisabled = true }: { includeDisabled?: boolean })`: Gets all the nested tree items in this node.
+
+**Events:**
+
+- `wa-expand`: Emitted when the tree item expands.
+- `wa-after-expand`: Emitted after the tree item expands and all animations are complete.
+- `wa-collapse`: Emitted when the tree item collapses.
+- `wa-after-collapse`: Emitted after the tree item collapses and all animations are complete.
+- `wa-lazy-change`: Emitted when the tree item's lazy state changes.
+- `wa-lazy-load`: Emitted when a lazy item is selected. Use this event to asynchronously load data and append items to the tree before expanding. After appending new items, remove the `lazy` attribute to remove the loading state and update the tree.
+
+**CSS Custom Properties:**
+
+- `--show-duration`: The animation duration when expanding tree items. (Default: `200ms`)
+- `--hide-duration`: The animation duration when collapsing tree items. (Default: `200ms`)
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+- `item`: The tree item's container. This element wraps everything except slotted tree item children.
+- `indentation`: The tree item's indentation container.
+- `expand-button`: The container that wraps the tree item's expand button and spinner.
+- `spinner`: The spinner that shows when a lazy tree item is in the loading state.
+- `spinner__base`: The spinner's base part.
+- `label`: The tree item's label.
+- `children`: The container that wraps the tree item's nested children.
+- `checkbox`: The checkbox that shows when using multiselect.
+- `checkbox__base`: The checkbox's exported `base` part.
+- `checkbox__control`: The checkbox's exported `control` part.
+- `checkbox__checked-icon`: The checkbox's exported `checked-icon` part.
+- `checkbox__indeterminate-icon`: The checkbox's exported `indeterminate-icon` part.
+- `checkbox__label`: The checkbox's exported `label` part.
+
+**CSS States:**
+
+- `disabled`: Applied when the tree item is disabled.
+- `expanded`: Applied when the tree item is expanded.
+- `indeterminate`: Applied when the selection is indeterminate.
+- `selected`: Applied when the tree item is selected.
+
+#### `<wa-video>`
+
+**Description:** Videos are used to embed and play video content with custom controls, and captions.
+
+**Documentation:** https://webawesome.com/docs/components/video
+
+**Slots:**
+
+- `(default)`: The default slot. Place `<source>` and `<track>` elements for a single video. Alternatively, use the `src` attribute for a single source.
+- `controls-start`: Content inserted at the start of the controls bar (before play/pause). Used by `<wa-video-playlist>` to inject the prev button.
+- `controls-after-play`: Content inserted immediately after the play/pause button. Used by `<wa-video-playlist>` to inject the next button.
+- `poster-icon`: Icon shown on the poster play button. Defaults to a play-circle icon.
+- `play-icon`: Icon shown on the play/pause button when paused.
+- `pause-icon`: Icon shown on the play/pause button when playing.
+- `volume-icon`: Icon shown on the volume/mute button when audio is active.
+- `mute-icon`: Icon shown on the volume/mute button when muted or volume is 0.
+- `fullscreen-icon`: Icon shown on the fullscreen button when not in fullscreen.
+- `exit-fullscreen-icon`: Icon shown on the fullscreen button when in fullscreen.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `controls`: The video's controls preset. - `none` — no controls are shown. - `standard` — shows the timeline, play/pause, volume, captions, and fullscreen. - `full` — all of the above plus playback speed and picture-in-picture. (Type: `'none' | 'standard' | 'full'`, Default: `'standard'`)
+- `thumbnails`: A URL pointing to a WebVTT file for timeline thumbnail previews. (Type: `string`, Default: `''`)
+- `src`: The URL of the video source. For multiple formats, use `<source>` elements instead. (Type: `string`, Default: `''`)
+- `poster`: Poster image URL (Type: `string`, Default: `''`)
+- `title`: The video's title. (Type: `string`, Default: `''`)
+- `playing`: Indicates whether the video is currently playing. (Type: `boolean`, Default: `false`)
+- `muted`: When set, the video will be muted. (Type: `boolean`, Default: `false`)
+- `volume`: The video's volume. (Type: `number`, Default: `1`)
+- `duration`: The total duration of the video in seconds. (Type: `number`, Default: `0`)
+- `currentTime`: The current playback position in seconds. (Type: `number`, Default: `0`)
+- `autoplay`: Enables autoplay when the component connects. (Type: `boolean`, Default: `false`)
+- `loop`: Loops the video when playback ends. (Type: `boolean`, Default: `false`)
+- `autoplayMuted` (attribute: `autoplay-muted`): Enables autoplay in a muted state. (Type: `boolean`, Default: `false`)
+- `autoplayOnVisible` (attribute: `autoplay-on-visible`): Automatically resumes playback when the player scrolls back into view after being paused by scrolling out. (Type: `boolean`, Default: `false`)
+- `preload`: Controls how the browser preloads the video. Defaults to 'metadata' to minimize data usage. (Type: `'auto' | 'metadata' | 'none'`, Default: `'metadata'`)
+- `iconLibrary` (attribute: `icon-library`): Icon library used for all built-in control icons. Defaults to 'system'. (Type: `string`, Default: `'system'`)
+
+**Methods:**
+
+- `play()`: Starts playback.
+- `pause()`: Pauses playback.
+- `togglePlay()`: Toggles between play and pause.
+- `toggleMute()`: Toggles the muted state.
+- `seek(time: number)`: Seeks to a specific time in the video.
+- `setVolume(volume: number)`: Sets the volume level.
+- `setPlaybackRate(rate: number)`: Sets the playback rate (speed).
+- `requestFullscreen()`: Enters fullscreen mode.
+- `exitFullscreen()`: Exits fullscreen mode.
+- `getVideoElement()`: Gets the native video element.
+- `getState()`: Gets the current playback state.
+
+**Events:**
+
+- `play`: Emitted when playback begins.
+- `pause`: Emitted when playback stops.
+- `timeupdate`: Emitted when the time changes.
+- `volumechange`: Emitted when the volume changes.
+- `error`: Emitted when an error occurs while loading/playing.
+- `ended`: Emitted when playback ends.
+- `loadedmetadata`: Emitted when metadata has been loaded.
+
+**CSS Custom Properties:**
+
+- `--controls-color`: The text and icon color used throughout the controls overlay, title overlay, and mobile controls. (Default: `white`)
+- `--controls-background`: The background of the controls bar and mobile controls. (Default: `var(--wa-color-surface-default)`)
+- `--poster-play-button-background`: The background of the play button shown over the poster image. Also used to derive the hover state via color-mix(). (Default: `var(--wa-color-surface-default)`)
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+- `video`: The video element.
+- `controls`: The controls container.
+- `controls-overlay`: The overlay wrapping timeline and controls bar.
+- `timeline`: The timeline/scrubber container.
+- `progress`: The progress bar.
+- `thumbnail`: The thumbnail preview.
+- `poster-overlay`: The poster image overlay.
+- `poster-play-button`: The play button on the poster overlay.
+- `video-title-overlay`: The title text overlay.
+- `caption-overlay`: The custom caption overlay container.
+- `caption`: The caption text element.
+- `timeline-track`: The timeline slider's track (forwarded from wa-slider).
+- `timeline-indicator`: The timeline slider's filled indicator (forwarded from wa-slider).
+- `timeline-thumb`: The timeline slider's thumb (forwarded from wa-slider).
+
+#### `<wa-video-playlist>`
+
+**Description:** Video playlist wraps multiple videos into a playlist with navigation controls and a sidebar.
+
+**Documentation:** https://webawesome.com/docs/components/video-playlist
+
+**Slots:**
+
+- `(default)`: The default slot. Place `<wa-video>` elements to create a playlist.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `controls`: The controls preset forwarded to each child `<wa-video>`. (Type: `'none' | 'standard' | 'full'`, Default: `'full'`)
+- `iconLibrary` (attribute: `icon-library`): Icon library used for placeholder icons. (Type: `string`, Default: `'system'`)
+
+**Methods:**
+
+- `next()`: Plays the next video in the playlist.
+- `previous()`: Plays the previous video in the playlist.
+- `goTo(index: number)`: Jumps to the video at the given index.
+
+**Events:**
+
+- `wa-video-change`: Emitted when the active video changes.
+
+**CSS Parts:**
+
+- `base`: The component's base wrapper.
+- `playlist`: The playlist sidebar container.
+- `playlist-item`: An individual playlist item button.
+- `playlist-thumbnail`: The thumbnail image within a playlist item.
+- `playlist-title`: The title text within a playlist item.
+- `playlist-duration`: The duration text within a playlist item.
+
+#### `<wa-zoomable-frame>`
+
+**Description:** Zoomable frames embed iframe content with built-in controls for zooming, panning, and managing interaction.
+
+**Documentation:** https://webawesome.com/docs/components/zoomable-frame
+
+**Slots:**
+
+- `zoom-in-icon`: The slot that contains the zoom in icon.
+- `zoom-out-icon`: The slot that contains the zoom out icon.
+
+**Properties:**
+
+- `css`: One or more CSSResultGroup to include in the component's shadow root. Host styles are automatically prepended. (Type: `CSSResultGroup | undefined`, Default: `styles`)
+- `src`: The URL of the content to display. (Type: `string`)
+- `srcdoc`: Inline HTML to display. (Type: `string`)
+- `allowfullscreen`: Allows fullscreen mode. (Type: `boolean`, Default: `false`)
+- `loading`: Controls iframe loading behavior. (Type: `'eager' | 'lazy'`, Default: `'eager'`)
+- `referrerpolicy`: Controls referrer information. (Type: `string`)
+- `sandbox`: Security restrictions for the iframe. (Type: `string`)
+- `zoom`: The current zoom of the frame, e.g. 0 = 0% and 1 = 100%. (Type: `number`, Default: `1`)
+- `zoomLevels` (attribute: `zoom-levels`): The zoom levels to step through when using zoom controls. This does not restrict programmatic changes to the zoom. (Type: `string`, Default: `'25% 50% 75% 100% 125% 150% 175% 200%'`)
+- `withoutControls` (attribute: `without-controls`): Removes the zoom controls. (Type: `boolean`, Default: `false`)
+- `withoutInteraction` (attribute: `without-interaction`): Disables interaction when present. (Type: `boolean`, Default: `false`)
+- `withThemeSync` (attribute: `with-theme-sync`): Enables automatic theme syncing (light/dark mode and theme selector classes) from the host document to the iframe. (Type: `boolean`, Default: `false`)
+- `contentWindow`: Returns the internal iframe's `window` object. (Readonly property) (Type: `Window | null`)
+- `contentDocument`: Returns the internal iframe's `document` object. (Readonly property) (Type: `Document | null`)
+
+**Methods:**
+
+- `zoomIn()`: Zooms in to the next available zoom level.
+- `zoomOut()`: Zooms out to the previous available zoom level.
+
+**Events:**
+
+- `load`: Emitted when the internal iframe when it finishes loading.
+- `error`: Emitted from the internal iframe when it fails to load.
+
+**CSS Parts:**
+
+- `iframe`: The internal `<iframe>` element.
+- `controls`: The container that surrounds zoom control buttons.
+- `zoom-in-button`: The zoom in button.
+- `zoom-out-button`: The zoom out button.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "angular-awesome",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "private": false,
-  "description": "Angular 20+ wrappers for the Web Awesome 3.6.x web components framework",
+  "description": "Angular 20+ wrappers for the Web Awesome 3.7.x web components framework",
   "keywords": [
     "angular",
     "web-awesome",

--- a/skills/angular-awesome/SKILL.md
+++ b/skills/angular-awesome/SKILL.md
@@ -6,8 +6,7 @@ metadata:
 ---
 
 # Angular Awesome
-
-Angular 20+ standalone directives wrapping Web Awesome 3.6.x web components. Every `<wa-*>` tag has a corresponding `Wa*Directive` or `Wa*Component` that binds attributes as `@Input()` properties, emits custom events as `@Output()`, and exposes `nativeElement` for direct access.
+Angular 20+ standalone directives wrapping Web Awesome 3.7.x web components. Every `<wa-*>` tag has a corresponding `Wa*Directive` or `Wa*Component` that binds attributes as `@Input()` properties, emits custom events as `@Output()`, and exposes `nativeElement` for direct access.
 
 ## Quick Start
 

--- a/src/directives/copy-button/copy-button.directive.spec.ts
+++ b/src/directives/copy-button/copy-button.directive.spec.ts
@@ -14,6 +14,7 @@ import { WaCopyButtonDirective } from './copy-button.directive';
       [errorLabel]="errorLabel"
       [feedbackDuration]="feedbackDuration"
       [tooltipPlacement]="tooltipPlacement"
+      [tooltip]="tooltip"
       [disabled]="disabled"
       (wa-copy)="onCopy()"
       (wa-error)="onError($event)"
@@ -34,6 +35,7 @@ class TestHostComponent {
   errorLabel?: string;
   feedbackDuration?: number | string;
   tooltipPlacement?: string;
+  tooltip?: string;
   disabled?: boolean | string;
 
   showCopyIcon = false;
@@ -195,6 +197,16 @@ describe('WaCopyButtonDirective', () => {
       hostComponent.tooltipPlacement = placement;
       hostFixture.detectChanges();
       expect(copyButtonElement.getAttribute('tooltip-placement')).toBe(placement);
+    });
+  });
+
+  it('should set the tooltip property correctly', () => {
+    const modes: string[] = ['full', 'copy', 'none'];
+
+    modes.forEach(mode => {
+      hostComponent.tooltip = mode;
+      hostFixture.detectChanges();
+      expect(copyButtonElement.getAttribute('tooltip')).toBe(mode);
     });
   });
 });

--- a/src/directives/copy-button/copy-button.directive.ts
+++ b/src/directives/copy-button/copy-button.directive.ts
@@ -32,6 +32,9 @@ export class WaCopyButtonDirective implements OnInit, OnChanges {
   // Numeric inputs
   @Input() feedbackDuration?: number | string;
 
+  // Tooltip control
+  @Input() tooltip?: 'full' | 'copy' | 'none' | string;
+
   // Placement input
   @Input() tooltipPlacement?: 'top' | 'right' | 'bottom' | 'left' | string;
 
@@ -77,6 +80,7 @@ export class WaCopyButtonDirective implements OnInit, OnChanges {
     this.setAttr('success-label', this.successLabel);
     this.setAttr('error-label', this.errorLabel);
     this.setAttr('tooltip-placement', this.tooltipPlacement);
+    this.setAttr('tooltip', this.tooltip);
 
     // Set numeric attributes
     this.setNumericAttr('feedback-duration', this.feedbackDuration);

--- a/src/directives/copy-button/copy-button.rules.md
+++ b/src/directives/copy-button/copy-button.rules.md
@@ -16,16 +16,17 @@ waCopyButton
 
 ### Inputs
 
-| Input              | Type      | Binding Required | Notes                                                      |          |          |                    |
-| ------------------ | --------- | ---------------- | ---------------------------------------------------------- | -------- | -------- | ------------------ |
-| `value`            | `string`  | Optional         | Text value to copy. Ignored if `from` is set.              |          |          |                    |
-| `from`             | `string`  | Optional         | Target element's ID. Supports `[attr]` and `.prop` syntax. |          |          |                    |
-| `copyLabel`        | `string`  | Optional         | Tooltip label before copy.                                 |          |          |                    |
-| `successLabel`     | `string`  | Optional         | Tooltip label on success.                                  |          |          |                    |
-| `errorLabel`       | `string`  | Optional         | Tooltip label on error.                                    |          |          |                    |
-| `feedbackDuration` | `number`  | Optional         | Tooltip visibility duration in ms.                         |          |          |                    |
-| `tooltipPlacement` | \`'top'   | 'right'          | 'bottom'                                                   | 'left'\` | Optional | Tooltip placement. |
-| `disabled`         | `boolean` | Optional         | Use with `booleanAttribute` binding.                       |          |          |                    |
+| Input              | Type      | Binding Required | Notes                                                       |          |          |                    |
+| ------------------ | --------- | ---------------- |-------------------------------------------------------------| -------- | -------- | ------------------ |
+| `value`            | `string`  | Optional         | Text value to copy. Ignored if `from` is set.               |          |          |                    |
+| `from`             | `string`  | Optional         | Target element's ID. Supports `[attr]` and `.prop` syntax.  |          |          |                    |
+| `copyLabel`        | `string`  | Optional         | Tooltip label before copy.                                  |          |          |                    |
+| `successLabel`     | `string`  | Optional         | Tooltip label on success.                                   |          |          |                    |
+| `errorLabel`       | `string`  | Optional         | Tooltip label on error.                                     |          |          |                    |
+| `feedbackDuration` | `number`  | Optional         | Tooltip visibility duration in ms.                          |          |          |                    |
+| `tooltipPlacement` | \`'top'   | 'right'          | 'bottom'                                                    | 'left'\` | Optional | Tooltip placement. |
+| `tooltip`          | \`'full'  | 'copy'           | 'none'\`                                                    | Optional | Controls the built-in tooltip. `full` shows on hover/focus and during copy feedback. `copy` only shows during feedback. `none` disables. |                    |
+| `disabled`         | `boolean` | Optional         | Use with `booleanAttribute` binding.                        |          |          |                    |
 
 ### Outputs
 

--- a/src/directives/video/index.ts
+++ b/src/directives/video/index.ts
@@ -1,0 +1,2 @@
+export * from './video.directive';
+export * from './video-playlist.directive';

--- a/src/directives/video/video-playlist.directive.spec.ts
+++ b/src/directives/video/video-playlist.directive.spec.ts
@@ -1,0 +1,92 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { WaVideoPlaylistDirective } from './video-playlist.directive';
+
+@Component({
+  template: `
+    <wa-video-playlist
+      [controls]="controls"
+      [iconLibrary]="iconLibrary"
+      (waVideoChange)="onVideoChange($event)"
+    ></wa-video-playlist>
+  `,
+  standalone: true,
+  imports: [WaVideoPlaylistDirective]
+})
+class TestHostComponent {
+  controls?: string;
+  iconLibrary?: string;
+
+  onVideoChange(_event: Event): void {}
+}
+
+describe('WaVideoPlaylistDirective', () => {
+  let hostComponent: TestHostComponent;
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let playlistElement: HTMLElement;
+  let playlistDirective: WaVideoPlaylistDirective;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent]
+    }).compileComponents();
+
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+    hostFixture.detectChanges();
+
+    playlistElement = hostFixture.nativeElement.querySelector('wa-video-playlist');
+    playlistDirective = hostFixture.debugElement.query(sel => sel.nativeElement === playlistElement).injector.get(WaVideoPlaylistDirective);
+  });
+
+  it('should create the video-playlist directive', () => {
+    expect(hostComponent).toBeTruthy();
+    expect(playlistElement).toBeTruthy();
+    expect(playlistDirective).toBeTruthy();
+  });
+
+  it('should set string attributes correctly', () => {
+    hostComponent.controls = 'standard';
+    hostComponent.iconLibrary = 'default';
+    hostFixture.detectChanges();
+
+    expect(playlistElement.getAttribute('controls')).toBe('standard');
+    expect(playlistElement.getAttribute('icon-library')).toBe('default');
+  });
+
+  it('should remove attributes when set to undefined', () => {
+    hostComponent.controls = 'full';
+    hostFixture.detectChanges();
+    expect(playlistElement.getAttribute('controls')).toBe('full');
+
+    hostComponent.controls = undefined;
+    hostFixture.detectChanges();
+    expect(playlistElement.hasAttribute('controls')).toBeFalse();
+  });
+
+  it('should expose the native element', () => {
+    expect(playlistDirective.nativeElement).toBe(playlistElement);
+  });
+
+  it('should emit wa-video-change event', () => {
+    spyOn(hostComponent, 'onVideoChange');
+
+    playlistElement.dispatchEvent(new Event('wa-video-change'));
+
+    expect(hostComponent.onVideoChange).toHaveBeenCalled();
+  });
+
+  it('should expose programmatic methods', () => {
+    (playlistElement as any).next = jasmine.createSpy('next');
+    (playlistElement as any).previous = jasmine.createSpy('previous');
+    (playlistElement as any).goTo = jasmine.createSpy('goTo');
+
+    playlistDirective.next();
+    playlistDirective.previous();
+    playlistDirective.goTo(2);
+
+    expect((playlistElement as any).next).toHaveBeenCalled();
+    expect((playlistElement as any).previous).toHaveBeenCalled();
+    expect((playlistElement as any).goTo).toHaveBeenCalledWith(2);
+  });
+});

--- a/src/directives/video/video-playlist.directive.ts
+++ b/src/directives/video/video-playlist.directive.ts
@@ -1,0 +1,89 @@
+import { Directive, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, Renderer2, inject } from '@angular/core';
+
+/**
+ * WaVideoPlaylistDirective
+ *
+ * Angular wrapper for the <wa-video-playlist> Web Component.
+ * Video playlist wraps multiple videos into a playlist with navigation controls and a sidebar.
+ *
+ * Features:
+ * - Binds all supported attributes as @Input() properties
+ * - Supports controls and iconLibrary configuration
+ * - Emits wa-video-change event when the active video changes
+ * - Provides programmatic methods (next, previous, goTo)
+ * - Allows slot projection for <wa-video> elements
+ * - Supports custom styling via CSS custom properties
+ */
+@Directive({
+  selector: 'wa-video-playlist',
+  standalone: true
+})
+export class WaVideoPlaylistDirective implements OnInit, OnChanges, OnDestroy {
+  /** The controls preset forwarded to each child <wa-video>. */
+  @Input() controls?: 'none' | 'standard' | 'full' | string;
+
+  /** Icon library used for placeholder icons. */
+  @Input() iconLibrary?: string;
+
+  // Event outputs
+  @Output() waVideoChange = new EventEmitter<Event>();
+  @Output('wa-video-change') waVideoChangeHyphen = this.waVideoChange;
+
+  // Injected services
+  private el = inject(ElementRef);
+  private renderer = inject(Renderer2);
+  private eventCleanups: (() => void)[] = [];
+
+  ngOnInit() {
+    this.applyInputs();
+    this.setupEventListeners();
+  }
+
+  ngOnChanges(_: SimpleChanges): void {
+    this.applyInputs();
+  }
+
+  private applyInputs() {
+    this.setAttr('controls', this.controls);
+    this.setAttr('icon-library', this.iconLibrary);
+  }
+
+  private setupEventListeners() {
+    const native = this.el.nativeElement;
+    this.eventCleanups.push(
+      this.renderer.listen(native, 'wa-video-change', (e: Event) => this.waVideoChange.emit(e)),
+    );
+  }
+
+  /** Plays the next video in the playlist. */
+  public next(): void {
+    (this.el.nativeElement as any).next();
+  }
+
+  /** Plays the previous video in the playlist. */
+  public previous(): void {
+    (this.el.nativeElement as any).previous();
+  }
+
+  /** Jumps to the video at the given index. */
+  public goTo(index: number): void {
+    (this.el.nativeElement as any).goTo(index);
+  }
+
+  /** Exposes the native element for direct interaction. */
+  public get nativeElement(): HTMLElement {
+    return this.el.nativeElement;
+  }
+
+  private setAttr(name: string, value: string | null | undefined) {
+    if (value != null) {
+      this.renderer.setAttribute(this.el.nativeElement, name, value);
+    } else {
+      this.renderer.removeAttribute(this.el.nativeElement, name);
+    }
+  }
+
+  ngOnDestroy() {
+    this.eventCleanups.forEach(fn => fn());
+  }
+}

--- a/src/directives/video/video.directive.spec.ts
+++ b/src/directives/video/video.directive.spec.ts
@@ -1,0 +1,193 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+import { WaVideoDirective } from './video.directive';
+
+@Component({
+  template: `
+    <wa-video
+      [controls]="controls"
+      [src]="src"
+      [poster]="poster"
+      [title]="title"
+      [thumbnails]="thumbnails"
+      [playing]="playing"
+      [muted]="muted"
+      [volume]="volume"
+      [currentTime]="currentTime"
+      [autoplay]="autoplay"
+      [loop]="loop"
+      [autoplayMuted]="autoplayMuted"
+      [autoplayOnVisible]="autoplayOnVisible"
+      [preload]="preload"
+      [iconLibrary]="iconLibrary"
+      (waPlay)="onPlay($event)"
+      (waPause)="onPause($event)"
+      (waEnded)="onEnded($event)"
+    ></wa-video>
+  `,
+  standalone: true,
+  imports: [WaVideoDirective]
+})
+class TestHostComponent {
+  controls?: string;
+  src?: string;
+  poster?: string;
+  title?: string;
+  thumbnails?: string;
+  playing?: boolean | string;
+  muted?: boolean | string;
+  volume?: number | string;
+  currentTime?: number | string;
+  autoplay?: boolean | string;
+  loop?: boolean | string;
+  autoplayMuted?: boolean | string;
+  autoplayOnVisible?: boolean | string;
+  preload?: string;
+  iconLibrary?: string;
+
+  onPlay(_event: Event): void {}
+  onPause(_event: Event): void {}
+  onEnded(_event: Event): void {}
+}
+
+describe('WaVideoDirective', () => {
+  let hostComponent: TestHostComponent;
+  let hostFixture: ComponentFixture<TestHostComponent>;
+  let videoElement: HTMLElement;
+  let videoDirective: WaVideoDirective;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent]
+    }).compileComponents();
+
+    hostFixture = TestBed.createComponent(TestHostComponent);
+    hostComponent = hostFixture.componentInstance;
+    hostFixture.detectChanges();
+
+    videoElement = hostFixture.nativeElement.querySelector('wa-video');
+    videoDirective = hostFixture.debugElement.query(sel => sel.nativeElement === videoElement).injector.get(WaVideoDirective);
+  });
+
+  it('should create the video directive', () => {
+    expect(hostComponent).toBeTruthy();
+    expect(videoElement).toBeTruthy();
+    expect(videoDirective).toBeTruthy();
+  });
+
+  it('should set string attributes correctly', () => {
+    hostComponent.controls = 'full';
+    hostComponent.src = 'video.mp4';
+    hostComponent.poster = 'poster.jpg';
+    hostComponent.title = 'My Video';
+    hostComponent.preload = 'auto';
+    hostComponent.iconLibrary = 'default';
+    hostFixture.detectChanges();
+
+    expect(videoElement.getAttribute('controls')).toBe('full');
+    expect(videoElement.getAttribute('src')).toBe('video.mp4');
+    expect(videoElement.getAttribute('poster')).toBe('poster.jpg');
+    expect(videoElement.getAttribute('title')).toBe('My Video');
+    expect(videoElement.getAttribute('preload')).toBe('auto');
+    expect(videoElement.getAttribute('icon-library')).toBe('default');
+  });
+
+  it('should set boolean attributes correctly', () => {
+    hostComponent.playing = true;
+    hostComponent.muted = true;
+    hostComponent.autoplay = true;
+    hostComponent.loop = true;
+    hostComponent.autoplayMuted = true;
+    hostComponent.autoplayOnVisible = true;
+    hostFixture.detectChanges();
+
+    expect(videoElement.hasAttribute('playing')).toBeTrue();
+    expect(videoElement.hasAttribute('muted')).toBeTrue();
+    expect(videoElement.hasAttribute('autoplay')).toBeTrue();
+    expect(videoElement.hasAttribute('loop')).toBeTrue();
+    expect(videoElement.hasAttribute('autoplay-muted')).toBeTrue();
+    expect(videoElement.hasAttribute('autoplay-on-visible')).toBeTrue();
+  });
+
+  it('should remove boolean attributes when false', () => {
+    hostComponent.playing = false;
+    hostComponent.muted = false;
+    hostComponent.autoplay = false;
+    hostComponent.loop = false;
+    hostFixture.detectChanges();
+
+    expect(videoElement.hasAttribute('playing')).toBeFalse();
+    expect(videoElement.hasAttribute('muted')).toBeFalse();
+    expect(videoElement.hasAttribute('autoplay')).toBeFalse();
+    expect(videoElement.hasAttribute('loop')).toBeFalse();
+  });
+
+  it('should set numeric attributes correctly', () => {
+    hostComponent.volume = 0.5;
+    hostComponent.currentTime = 30;
+    hostFixture.detectChanges();
+
+    expect(videoElement.getAttribute('volume')).toBe('0.5');
+    expect(videoElement.getAttribute('current-time')).toBe('30');
+  });
+
+  it('should expose the native element', () => {
+    expect(videoDirective.nativeElement).toBe(videoElement);
+  });
+
+  it('should emit play event', () => {
+    spyOn(hostComponent, 'onPlay');
+
+    videoElement.dispatchEvent(new Event('play'));
+
+    expect(hostComponent.onPlay).toHaveBeenCalled();
+  });
+
+  it('should emit pause event', () => {
+    spyOn(hostComponent, 'onPause');
+
+    videoElement.dispatchEvent(new Event('pause'));
+
+    expect(hostComponent.onPause).toHaveBeenCalled();
+  });
+
+  it('should emit ended event', () => {
+    spyOn(hostComponent, 'onEnded');
+
+    videoElement.dispatchEvent(new Event('ended'));
+
+    expect(hostComponent.onEnded).toHaveBeenCalled();
+  });
+
+  it('should expose programmatic methods', () => {
+    (videoElement as any).play = jasmine.createSpy('play');
+    (videoElement as any).pause = jasmine.createSpy('pause');
+    (videoElement as any).togglePlay = jasmine.createSpy('togglePlay');
+    (videoElement as any).toggleMute = jasmine.createSpy('toggleMute');
+    (videoElement as any).seek = jasmine.createSpy('seek');
+    (videoElement as any).setVolume = jasmine.createSpy('setVolume');
+    (videoElement as any).setPlaybackRate = jasmine.createSpy('setPlaybackRate');
+    (videoElement as any).requestFullscreen = jasmine.createSpy('requestFullscreen');
+    (videoElement as any).exitFullscreen = jasmine.createSpy('exitFullscreen');
+
+    videoDirective.play();
+    videoDirective.pause();
+    videoDirective.togglePlay();
+    videoDirective.toggleMute();
+    videoDirective.seek(10);
+    videoDirective.setVolume(0.8);
+    videoDirective.setPlaybackRate(1.5);
+    videoDirective.requestFullscreen();
+    videoDirective.exitFullscreen();
+
+    expect((videoElement as any).play).toHaveBeenCalled();
+    expect((videoElement as any).pause).toHaveBeenCalled();
+    expect((videoElement as any).togglePlay).toHaveBeenCalled();
+    expect((videoElement as any).toggleMute).toHaveBeenCalled();
+    expect((videoElement as any).seek).toHaveBeenCalledWith(10);
+    expect((videoElement as any).setVolume).toHaveBeenCalledWith(0.8);
+    expect((videoElement as any).setPlaybackRate).toHaveBeenCalledWith(1.5);
+    expect((videoElement as any).requestFullscreen).toHaveBeenCalled();
+    expect((videoElement as any).exitFullscreen).toHaveBeenCalled();
+  });
+});

--- a/src/directives/video/video.directive.ts
+++ b/src/directives/video/video.directive.ts
@@ -1,0 +1,227 @@
+import { Directive, ElementRef, EventEmitter, Input, OnChanges, OnDestroy, OnInit, Output, SimpleChanges, Renderer2, inject } from '@angular/core';
+
+/**
+ * WaVideoDirective
+ *
+ * Angular wrapper for the <wa-video> Web Component.
+ * Videos are used to embed and play video content with custom controls, and captions.
+ *
+ * Features:
+ * - Binds all supported video attributes as @Input() properties
+ * - Supports boolean attributes like playing, muted, autoplay, loop, autoplayMuted, autoplayOnVisible
+ * - Supports numeric attributes like volume, duration, currentTime
+ * - Supports string attributes like controls, src, poster, title, thumbnails, preload, iconLibrary
+ * - Emits playback events (play, pause, timeupdate, volumechange, error, ended, loadedmetadata)
+ * - Provides programmatic methods (play, pause, togglePlay, seek, etc.)
+ * - Allows slot projection for source/track elements and icon customisation
+ * - Supports custom styling via CSS custom properties
+ */
+@Directive({
+  selector: 'wa-video',
+  standalone: true
+})
+export class WaVideoDirective implements OnInit, OnChanges, OnDestroy {
+  /** The video's controls preset. */
+  @Input() controls?: 'none' | 'standard' | 'full' | string;
+
+  /** A URL pointing to a WebVTT file for timeline thumbnail previews. */
+  @Input() thumbnails?: string;
+
+  /** The URL of the video source. For multiple formats, use <source> elements instead. */
+  @Input() src?: string;
+
+  /** Poster image URL. */
+  @Input() poster?: string;
+
+  /** The video's title. */
+  @Input() title?: string;
+
+  /** Indicates whether the video is currently playing. */
+  @Input() playing?: boolean | string;
+
+  /** When set, the video will be muted. */
+  @Input() muted?: boolean | string;
+
+  /** The video's volume (0–1). */
+  @Input() volume?: number | string;
+
+  /** The total duration of the video in seconds (read-only from the element). */
+  @Input() duration?: number | string;
+
+  /** The current playback position in seconds. */
+  @Input() currentTime?: number | string;
+
+  /** Enables autoplay when the component connects. */
+  @Input() autoplay?: boolean | string;
+
+  /** Loops the video when playback ends. */
+  @Input() loop?: boolean | string;
+
+  /** Enables autoplay in a muted state. */
+  @Input() autoplayMuted?: boolean | string;
+
+  /** Automatically resumes playback when the player scrolls back into view. */
+  @Input() autoplayOnVisible?: boolean | string;
+
+  /** Controls how the browser preloads the video. */
+  @Input() preload?: 'auto' | 'metadata' | 'none' | string;
+
+  /** Icon library used for all built-in control icons. */
+  @Input() iconLibrary?: string;
+
+  // Event outputs
+  @Output() waPlay = new EventEmitter<Event>();
+  @Output('play') waPlayNative = this.waPlay;
+  @Output() waPause = new EventEmitter<Event>();
+  @Output('pause') waPauseNative = this.waPause;
+  @Output() waTimeupdate = new EventEmitter<Event>();
+  @Output('timeupdate') waTimeupdateNative = this.waTimeupdate;
+  @Output() waVolumechange = new EventEmitter<Event>();
+  @Output('volumechange') waVolumechangeNative = this.waVolumechange;
+  @Output() waError = new EventEmitter<Event>();
+  @Output('error') waErrorNative = this.waError;
+  @Output() waEnded = new EventEmitter<Event>();
+  @Output('ended') waEndedNative = this.waEnded;
+  @Output() waLoadedmetadata = new EventEmitter<Event>();
+  @Output('loadedmetadata') waLoadedmetadataNative = this.waLoadedmetadata;
+
+  // Injected services
+  private el = inject(ElementRef);
+  private renderer = inject(Renderer2);
+  private eventCleanups: (() => void)[] = [];
+
+  ngOnInit() {
+    this.applyInputs();
+    this.setupEventListeners();
+  }
+
+  ngOnChanges(_: SimpleChanges): void {
+    this.applyInputs();
+  }
+
+  private applyInputs() {
+    this.setAttr('controls', this.controls);
+    this.setAttr('thumbnails', this.thumbnails);
+    this.setAttr('src', this.src);
+    this.setAttr('poster', this.poster);
+    this.setAttr('title', this.title);
+    this.setAttr('preload', this.preload);
+    this.setAttr('icon-library', this.iconLibrary);
+
+    this.setBooleanAttr('playing', this.playing);
+    this.setBooleanAttr('muted', this.muted);
+    this.setBooleanAttr('autoplay', this.autoplay);
+    this.setBooleanAttr('loop', this.loop);
+    this.setBooleanAttr('autoplay-muted', this.autoplayMuted);
+    this.setBooleanAttr('autoplay-on-visible', this.autoplayOnVisible);
+
+    this.setNumericAttr('volume', this.volume);
+    this.setNumericAttr('duration', this.duration);
+    this.setNumericAttr('current-time', this.currentTime);
+  }
+
+  private setupEventListeners() {
+    const native = this.el.nativeElement;
+
+    this.eventCleanups.push(
+      this.renderer.listen(native, 'play', (e: Event) => this.waPlay.emit(e)),
+      this.renderer.listen(native, 'pause', (e: Event) => this.waPause.emit(e)),
+      this.renderer.listen(native, 'timeupdate', (e: Event) => this.waTimeupdate.emit(e)),
+      this.renderer.listen(native, 'volumechange', (e: Event) => this.waVolumechange.emit(e)),
+      this.renderer.listen(native, 'error', (e: Event) => this.waError.emit(e)),
+      this.renderer.listen(native, 'ended', (e: Event) => this.waEnded.emit(e)),
+      this.renderer.listen(native, 'loadedmetadata', (e: Event) => this.waLoadedmetadata.emit(e)),
+    );
+  }
+
+  /** Starts playback. */
+  public play(): void {
+    (this.el.nativeElement as any).play();
+  }
+
+  /** Pauses playback. */
+  public pause(): void {
+    (this.el.nativeElement as any).pause();
+  }
+
+  /** Toggles between play and pause. */
+  public togglePlay(): void {
+    (this.el.nativeElement as any).togglePlay();
+  }
+
+  /** Toggles the muted state. */
+  public toggleMute(): void {
+    (this.el.nativeElement as any).toggleMute();
+  }
+
+  /** Seeks to a specific time in the video. */
+  public seek(time: number): void {
+    (this.el.nativeElement as any).seek(time);
+  }
+
+  /** Sets the volume level (0–1). */
+  public setVolume(volume: number): void {
+    (this.el.nativeElement as any).setVolume(volume);
+  }
+
+  /** Sets the playback rate (speed). */
+  public setPlaybackRate(rate: number): void {
+    (this.el.nativeElement as any).setPlaybackRate(rate);
+  }
+
+  /** Enters fullscreen mode. */
+  public requestFullscreen(): void {
+    (this.el.nativeElement as any).requestFullscreen();
+  }
+
+  /** Exits fullscreen mode. */
+  public exitFullscreen(): void {
+    (this.el.nativeElement as any).exitFullscreen();
+  }
+
+  /** Gets the native video element. */
+  public getVideoElement(): HTMLVideoElement {
+    return (this.el.nativeElement as any).getVideoElement();
+  }
+
+  /** Gets the current playback state. */
+  public getState(): unknown {
+    return (this.el.nativeElement as any).getState();
+  }
+
+  /** Exposes the native element for direct interaction. */
+  public get nativeElement(): HTMLElement {
+    return this.el.nativeElement;
+  }
+
+  private setAttr(name: string, value: string | null | undefined) {
+    if (value != null) {
+      this.renderer.setAttribute(this.el.nativeElement, name, value);
+    } else {
+      this.renderer.removeAttribute(this.el.nativeElement, name);
+    }
+  }
+
+  private setNumericAttr(name: string, value: number | string | null | undefined) {
+    if (value != null) {
+      const numericValue = typeof value === 'string' ? parseFloat(value) : value;
+      if (!isNaN(numericValue)) {
+        this.renderer.setAttribute(this.el.nativeElement, name, numericValue.toString());
+      }
+    } else {
+      this.renderer.removeAttribute(this.el.nativeElement, name);
+    }
+  }
+
+  private setBooleanAttr(name: string, value: boolean | string | null | undefined) {
+    if (value === true || value === 'true' || value === '') {
+      this.renderer.setAttribute(this.el.nativeElement, name, '');
+    } else {
+      this.renderer.removeAttribute(this.el.nativeElement, name);
+    }
+  }
+
+  ngOnDestroy() {
+    this.eventCleanups.forEach(fn => fn());
+  }
+}

--- a/src/directives/video/video.example.md
+++ b/src/directives/video/video.example.md
@@ -1,0 +1,150 @@
+# Video Examples
+
+## Basic Usage (src attribute)
+
+```html
+<wa-video src="https://example.com/video.mp4" controls="standard"></wa-video>
+```
+
+## With Poster and Title
+
+```html
+<wa-video
+  src="https://example.com/video.mp4"
+  poster="https://example.com/poster.jpg"
+  title="Introduction to Angular Awesome"
+  controls="full">
+</wa-video>
+```
+
+## Multiple Sources with Captions
+
+```html
+<wa-video controls="full" title="Demo Video">
+  <source src="video.mp4" type="video/mp4">
+  <source src="video.webm" type="video/webm">
+  <track kind="subtitles" src="captions.vtt" srclang="en" label="English">
+</wa-video>
+```
+
+## Autoplay (Muted)
+
+```html
+<wa-video src="hero.mp4" autoplay-muted loop controls="none"></wa-video>
+```
+
+## Autoplay On Visible
+
+```html
+<wa-video
+  src="demo.mp4"
+  autoplay-on-visible
+  muted
+  controls="standard">
+</wa-video>
+```
+
+## Angular Bindings
+
+```html
+<wa-video
+  [src]="videoUrl"
+  [poster]="posterUrl"
+  [title]="videoTitle"
+  [controls]="controlsPreset"
+  [muted]="isMuted"
+  [volume]="volumeLevel"
+  [autoplay]="shouldAutoplay"
+  [loop]="shouldLoop"
+  [preload]="preloadStrategy"
+  (waPlay)="onPlay()"
+  (waPause)="onPause()"
+  (waEnded)="onEnded()"
+  (waTimeupdate)="onTimeUpdate($event)"
+  (waError)="onError($event)">
+</wa-video>
+```
+
+## Programmatic Control
+
+```typescript
+import { Component, ViewChild } from '@angular/core';
+import { WaVideoDirective } from 'angular-awesome';
+
+@Component({
+  selector: 'app-video-demo',
+  standalone: true,
+  imports: [WaVideoDirective],
+  template: `
+    <wa-video #player src="demo.mp4" controls="full"></wa-video>
+    <div class="controls">
+      <button (click)="player.play()">Play</button>
+      <button (click)="player.pause()">Pause</button>
+      <button (click)="player.seek(30)">Skip to 30s</button>
+      <button (click)="player.setVolume(0.5)">50% Volume</button>
+      <button (click)="player.requestFullscreen()">Fullscreen</button>
+    </div>
+  `
+})
+export class VideoDemoComponent {}
+```
+
+## Video Playlist
+
+```html
+<wa-video-playlist controls="full" (waVideoChange)="onVideoChange($event)">
+  <wa-video
+    src="episode1.mp4"
+    poster="ep1-poster.jpg"
+    title="Episode 1: Getting Started">
+  </wa-video>
+  <wa-video
+    src="episode2.mp4"
+    poster="ep2-poster.jpg"
+    title="Episode 2: Core Concepts">
+  </wa-video>
+  <wa-video
+    src="episode3.mp4"
+    poster="ep3-poster.jpg"
+    title="Episode 3: Advanced Topics">
+  </wa-video>
+</wa-video-playlist>
+```
+
+## Playlist with Programmatic Navigation
+
+```typescript
+import { Component, ViewChild } from '@angular/core';
+import { WaVideoPlaylistDirective, WaVideoDirective } from 'angular-awesome';
+
+@Component({
+  selector: 'app-playlist-demo',
+  standalone: true,
+  imports: [WaVideoPlaylistDirective, WaVideoDirective],
+  template: `
+    <wa-video-playlist #playlist controls="full">
+      <wa-video src="ep1.mp4" title="Episode 1"></wa-video>
+      <wa-video src="ep2.mp4" title="Episode 2"></wa-video>
+      <wa-video src="ep3.mp4" title="Episode 3"></wa-video>
+    </wa-video-playlist>
+    <div>
+      <button (click)="playlist.previous()">Previous</button>
+      <button (click)="playlist.goTo(0)">First</button>
+      <button (click)="playlist.next()">Next</button>
+    </div>
+  `
+})
+export class PlaylistDemoComponent {}
+```
+
+## Custom Controls Preset — No Controls (Background Video)
+
+```html
+<wa-video
+  src="background.mp4"
+  controls="none"
+  autoplay-muted
+  loop
+  style="width: 100%; height: 400px; object-fit: cover;">
+</wa-video>
+```

--- a/src/directives/video/video.rules.md
+++ b/src/directives/video/video.rules.md
@@ -1,0 +1,144 @@
+📌 This directive assumes compliance with general [Web Awesome Angular Rules](../../../RULES.md).
+
+# Video (`wa-video`)
+
+This directive wraps the `<wa-video>` Web Awesome component to provide Angular integration for embedded video playback with custom controls, captions, and full programmatic control.
+
+## Selector
+
+```ts
+wa-video
+```
+
+## Projected Content
+
+Use `<source>` and `<track>` elements as children for multi-format video or captioning. For a single source, use the `[src]` input instead.
+
+## Inputs
+
+| Input              | Type                             | Attribute           | Notes                                                                |
+|--------------------|----------------------------------|---------------------|----------------------------------------------------------------------|
+| `controls`         | `'none' \| 'standard' \| 'full'` | `controls`          | Controls preset. Default: `'standard'`.                              |
+| `src`              | `string`                         | `src`               | URL of the video source.                                             |
+| `poster`           | `string`                         | `poster`            | Poster image URL shown before playback.                              |
+| `title`            | `string`                         | `title`             | Video title shown in the title overlay.                              |
+| `thumbnails`       | `string`                         | `thumbnails`        | URL to a WebVTT file for timeline thumbnail previews.                |
+| `playing`          | `boolean \| string`              | `playing`           | Indicates the video is currently playing.                            |
+| `muted`            | `boolean \| string`              | `muted`             | Mutes the video.                                                     |
+| `autoplay`         | `boolean \| string`              | `autoplay`          | Enables autoplay on connect.                                         |
+| `loop`             | `boolean \| string`              | `loop`              | Loops playback when ended.                                           |
+| `autoplayMuted`    | `boolean \| string`              | `autoplay-muted`    | Autoplay in muted state.                                             |
+| `autoplayOnVisible`| `boolean \| string`              | `autoplay-on-visible`| Resume playback when scrolled back into view.                       |
+| `volume`           | `number \| string`               | `volume`            | Volume level 0–1.                                                    |
+| `duration`         | `number \| string`               | `duration`          | Total duration in seconds (typically read-only from the element).    |
+| `currentTime`      | `number \| string`               | `current-time`      | Current playback position in seconds.                                |
+| `preload`          | `'auto' \| 'metadata' \| 'none'` | `preload`           | Browser preload strategy. Default: `'metadata'`.                     |
+| `iconLibrary`      | `string`                         | `icon-library`      | Icon library for built-in control icons.                             |
+
+## Outputs
+
+| Output            | Native event      | Description                                       |
+|-------------------|-------------------|---------------------------------------------------|
+| `waPlay`          | `play`            | Emitted when playback begins.                     |
+| `waPause`         | `pause`           | Emitted when playback is paused.                  |
+| `waTimeupdate`    | `timeupdate`      | Emitted periodically during playback.             |
+| `waVolumechange`  | `volumechange`    | Emitted when the volume changes.                  |
+| `waError`         | `error`           | Emitted when a loading or playback error occurs.  |
+| `waEnded`         | `ended`           | Emitted when playback reaches the end.            |
+| `waLoadedmetadata`| `loadedmetadata`  | Emitted when video metadata has loaded.           |
+
+Both camelCase (`waPlay`) and native (`play`) aliases are available.
+
+## Methods (Access via `@ViewChild`)
+
+| Method                       | Description                                  |
+|------------------------------|----------------------------------------------|
+| `play()`                     | Starts playback.                             |
+| `pause()`                    | Pauses playback.                             |
+| `togglePlay()`               | Toggles between play and pause.              |
+| `toggleMute()`               | Toggles the muted state.                     |
+| `seek(time: number)`         | Seeks to the given position in seconds.      |
+| `setVolume(volume: number)`  | Sets the volume level (0–1).                 |
+| `setPlaybackRate(rate: number)` | Sets the playback speed.                  |
+| `requestFullscreen()`        | Enters fullscreen mode.                      |
+| `exitFullscreen()`           | Exits fullscreen mode.                       |
+| `getVideoElement()`          | Returns the native `<video>` element.        |
+| `getState()`                 | Returns the current playback state object.   |
+
+## CSS Custom Properties
+
+| Property                         | Description                                              |
+|----------------------------------|----------------------------------------------------------|
+| `--controls-color`               | Text/icon color for controls overlays (default: `white`) |
+| `--controls-background`          | Background of the controls bar.                          |
+| `--poster-play-button-background`| Background of the poster play button.                    |
+
+## Slots
+
+| Slot Name             | Purpose                                                |
+|-----------------------|--------------------------------------------------------|
+| (default)             | `<source>` and `<track>` elements for multi-format     |
+| `controls-start`      | Content before play/pause (used by `wa-video-playlist`)|
+| `controls-after-play` | Content after play/pause (used by `wa-video-playlist`) |
+| `poster-icon`         | Icon on the poster play button.                        |
+| `play-icon`           | Icon for the play state.                               |
+| `pause-icon`          | Icon for the pause state.                              |
+| `volume-icon`         | Icon when audio is active.                             |
+| `mute-icon`           | Icon when muted.                                       |
+| `fullscreen-icon`     | Icon for enter-fullscreen button.                      |
+| `exit-fullscreen-icon`| Icon for exit-fullscreen button.                       |
+
+---
+
+# Video Playlist (`wa-video-playlist`)
+
+This directive wraps the `<wa-video-playlist>` Web Awesome component, grouping multiple `<wa-video>` elements into a playlist with navigation sidebar and controls.
+
+## Selector
+
+```ts
+wa-video-playlist
+```
+
+## Projected Content
+
+Place `<wa-video>` elements as direct children to form the playlist.
+
+## Inputs
+
+| Input         | Type                             | Attribute      | Notes                                             |
+|---------------|----------------------------------|----------------|---------------------------------------------------|
+| `controls`    | `'none' \| 'standard' \| 'full'` | `controls`     | Controls preset forwarded to each child video. Default: `'full'`. |
+| `iconLibrary` | `string`                         | `icon-library` | Icon library for placeholder icons.               |
+
+## Outputs
+
+| Output          | Native event       | Description                                |
+|-----------------|--------------------|--------------------------------------------|
+| `waVideoChange` | `wa-video-change`  | Emitted when the active video changes.     |
+
+## Methods (Access via `@ViewChild`)
+
+| Method              | Description                              |
+|---------------------|------------------------------------------|
+| `next()`            | Plays the next video in the playlist.    |
+| `previous()`        | Plays the previous video in the playlist.|
+| `goTo(index: number)` | Jumps to the video at the given index. |
+
+## CSS Parts
+
+| Part               | Description                             |
+|--------------------|-----------------------------------------|
+| `base`             | The component's base wrapper.           |
+| `playlist`         | The playlist sidebar container.         |
+| `playlist-item`    | An individual playlist item button.     |
+| `playlist-thumbnail` | The thumbnail image in a playlist item. |
+
+---
+
+## Notes
+
+- Use `[src]` for simple single-source videos; use `<source>` children for multi-format fallback.
+- The `autoplayMuted` input enables autoplay in environments that block unmuted autoplay.
+- Combine `wa-video-playlist` with `wa-video` children; playlist controls (`controls` input) override child video controls.
+- Events use native names (`play`, `pause`, etc.) — no `wa-` prefix unlike most other Web Awesome events.

--- a/src/public-api.ts
+++ b/src/public-api.ts
@@ -85,6 +85,8 @@ export * from './directives/polar-area-chart/polar-area-chart.directive';
 export * from './directives/radar-chart/radar-chart.directive';
 export * from './directives/scatter-chart/scatter-chart.directive';
 export * from './directives/markdown/markdown.directive';
+export * from './directives/video/video.directive';
+export * from './directives/video/video-playlist.directive';
 
 // Shared type tokens
 export * from './types/tokens';

--- a/src/types/tokens.ts
+++ b/src/types/tokens.ts
@@ -3,7 +3,7 @@
 // Core variants supported across components
 export type VariantToken = 'brand' | 'neutral' | 'success' | 'warning' | 'danger' | 'inherit';
 
-// Common control sizes (Web Awesome 3.6.0 added shorthand tokens xs/s/m/l/xl)
+// Common control sizes (Web Awesome 3.7.0 - shorthand tokens xs/s/m/l/xl added in 3.6.0)
 export type SizeToken = 'xs' | 's' | 'm' | 'l' | 'xl' | 'small' | 'medium' | 'large' | 'inherit';
 
 // Visual appearance tokens (Web Awesome 3.0.0)


### PR DESCRIPTION
## What's Changed
### Added
- **wa-video**: New \WaVideoDirective\ with full playback control (play/pause, seek, volume, fullscreen, PiP)
- **wa-video-playlist**: New \WaVideoPlaylistDirective\ with playlist navigation (next/previous/goTo)
- **wa-copy-button**: New \	ooltip\ input (\'full' | 'copy' | 'none'\) controlling built-in tooltip behavior
### Changed
- **wa-copy-button**: CSS parts updated — removed deprecated \	ooltip__base\, \	ooltip__base__popup\, \	ooltip__base__arrow\, \	ooltip__body\; replaced with single \eedback\ part
### Notes
- All 948 tests passing
- Aligned with Web Awesome 3.7.0 component specification
- No breaking changes to existing Angular API